### PR TITLE
Include MultiPoint as valid geometry for Feature

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -7,7 +7,7 @@ from .geometries import Point, MultiPoint, LineString, MultiLineString, \
 
 class Feature(BaseModel):
     type: str = Field("Feature", const=True)
-    geometry: Union[Point, MultiPolygon, LineString,  MultiLineString, Polygon, MultiPolygon]
+    geometry: Union[Point, MultiPoint, LineString,  MultiLineString, Polygon, MultiPolygon]
     properties: Optional[Dict[Any, Any]]
     id: Optional[str]
     bbox: Optional[BBox]


### PR DESCRIPTION
The Feature model now accepts MultiPoint as a valid geometry (before MultiPolygon was repeated twice and MultiPoint not included).