### PR TITLE
docs: Add documentation on how to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Below you'll find instructions on how to get your hands dirty in case you want
+to start hacking on this library.
+
+##  Hacking
+
+To run the tests, first install the package in a virtual environment:
+
+```sh
+virtualenv venv
+source venv/bin/activate
+pip install -e '.[test]'
+```
+
+You can then run the tests with the following command:
+
+```sh
+python -m pytest --cov geojson_pydantic --cov-report term-missing --ignore=venv
+```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 Pydantic data models for the GeoJSON spec
 
 Initial implementation by @geospatial-jeff; taken liberally from https://github.com/arturo-ai/stac-pydantic/
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Hi,

I'm not quite sure on if this is the preferred way for you to run/install tox, and/or if you even want the `CONTRIBUTING.md` file to be included.

Maybe `tox` should be included as a dev dependency somehow.

Personally I've switched 100% to `poetry`. I have not tested it with `tox` yet. I use GitHub actions matrix builds for testing different OSes and python versions. See https://github.com/hawkaa/pygeojson .

Let me know what you think!