### PR TITLE
chore: add package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ extra_reqs = {
     "dev": ["pytest", "pytest-cov", "pre-commit"],
 }
 
+package_data = {"": ["*"]}
+
 setup(
     name="geojson-pydantic",
     version="0.2.0",
@@ -37,4 +39,5 @@ setup(
     include_package_data=True,
     install_requires=inst_reqs,
     extras_require=extra_reqs,
+    package_data=package_data,
 )


### PR DESCRIPTION
I checked the generated ´setup.py` in my `pygeojson` package and I found out that `package_data` was missing here. This is also according to https://www.python.org/dev/peps/pep-0561/

I'm so sorry.