### PR TITLE
Fix version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,42 +3,28 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7
-        args: ["--safe"]
+        language_version: python
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
       - id: isort
-        language_version: python3.7
+        language_version: python
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.8.3
     hooks:
       - id: flake8
-        language_version: python3.7
-        args: [
-            # E501 let black handle all line length decisions
-            # W503 black conflicts with "line break before operator" rule
-            # E203 black conflicts with "whitespace before ':'" rule
-            "--ignore=E501,W503,E203",
-          ]
+        language_version: python
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 5.1.1
     hooks:
       - id: pydocstyle
-        language_version: python3.7
-        args: [
-            # Check for docstring presence only
-            "--select=D1",
-            # Don't require docstrings for tests
-            '--match=(?!test).*\.py',
-          ]
+        language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.770
+    rev: v0.812
     hooks:
       - id: mypy
-        language_version: python3.7
-        args: ["--no-strict-optional", "--ignore-missing-imports"]
+        language_version: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 
 # Change Log
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.2.2.post1] - 2021-05-05
+
+## Fixed
+- incorrect version number set in `__init__.py`
 
 ## [0.2.2] - 2020-12-29
 
@@ -17,7 +22,7 @@ Although the type file was added in `0.2.0` it wasn't included in the distribute
 
 ## Fixed
 - Correct package type information files
- 
+
 ## [0.2.0] - 2020-08-06
 
 ### Added
@@ -26,11 +31,11 @@ Although the type file was added in `0.2.0` it wasn't included in the distribute
 
 ### Changed
 - Removed geojson dependency (#4)
- 
+
 ### Fixed
 - Include MultiPoint as a valid geometry for a Feature (#1)
- 
+
 ## [0.1.0] - 2020-05-21
- 
+
 ### Added
 - Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2.2.post1] - 2021-05-05
+## [0.2.3] - 2021-05-05
 
 ## Fixed
 - incorrect version number set in `__init__.py`

--- a/geojson_pydantic/__init__.py
+++ b/geojson_pydantic/__init__.py
@@ -1,3 +1,3 @@
 """geojson-pydantic."""
 
-version = "0.2.1"
+version = "0.2.2.post1"

--- a/geojson_pydantic/__init__.py
+++ b/geojson_pydantic/__init__.py
@@ -1,3 +1,3 @@
 """geojson-pydantic."""
 
-version = "0.2.2.post1"
+version = "0.2.3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2.post1
+current_version = 0.2.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2.post1
 commit = True
 tag = True
 tag_name = {new_version}
@@ -11,3 +11,22 @@ replace = version="{new_version}"
 [bumpversion:file:geojson_pydantic/__init__.py]
 search = version = "{current_version}"
 replace = version = "{new_version}"
+
+[isort]
+profile = black
+known_first_party = geojson_pydantic
+known_third_party = geojson, pydantic
+default_section = THIRDPARTY
+
+[flake8]
+ignore = E501,W503,E203
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+max-line-length = 90
+
+[mypy]
+no_strict_optional = True
+ignore_missing_imports = True
+
+[pydocstyle]
+select = D1
+match = (?!test).*\.py

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extra_reqs = {
 
 setup(
     name="geojson-pydantic",
-    version="0.2.2.post1",
+    version="0.2.3",
     python_requires=">=3.6",
     description=u"""Pydantic data models for the GeoJSON spec""",
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extra_reqs = {
 
 setup(
     name="geojson-pydantic",
-    version="0.2.2",
+    version="0.2.2.post1",
     python_requires=">=3.6",
     description=u"""Pydantic data models for the GeoJSON spec""",
     long_description=readme,
@@ -24,6 +24,7 @@ setup(
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,10 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 [testenv]
 extras = test
 commands=
     python -m pytest --cov geojson_pydantic --cov-report xml --cov-report term-missing --ignore=venv
-
-# Lint
-[flake8]
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
-max-line-length = 90
-
-[mypy]
-no_strict_optional = True
-ignore_missing_imports = True
-
-[tool:isort]
-profile=black
-known_first_party = geojson_pydantic
-known_third_party = geojson, pydantic
-default_section = THIRDPARTY
-
 
 # Release tooling
 [testenv:build]


### PR DESCRIPTION
closes #24 

This PR does:
- update pre-commit config to run on any python version
- add python 3.9 in the CI 
- move config lint config from tox.ini to setup.cfg
- fix #24 