### PR TITLE
rename utils.py and move position variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - Drop python 3.6 support
+- Renamed `utils.py` to `types.py`
+- Removed `Coordinate` type in `geojson_pydantic.features` (replaced by `Position`)
 
 ## [0.2.3] - 2021-05-05
 

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -5,8 +5,8 @@ from typing import Dict, Generic, List, Optional, TypeVar
 from pydantic import Field, validator
 from pydantic.generics import GenericModel
 
-from .geometries import Geometry
-from .utils import BBox
+from geojson_pydantic.geometries import Geometry
+from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
 Geom = TypeVar("Geom", bound=Geometry)

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -1,15 +1,12 @@
 """pydantic models for GeoJSON Geometry objects."""
 
 import abc
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
 
-from .utils import NumType
-
-Coordinate = Union[Tuple[NumType, NumType], Tuple[NumType, NumType, NumType]]
-Position = Coordinate
+from geojson_pydantic.types import Position
 
 
 class _GeometryBase(BaseModel, abc.ABC):
@@ -26,35 +23,35 @@ class Point(_GeometryBase):
     """Point Model"""
 
     type: str = Field("Point", const=True)
-    coordinates: Coordinate
+    coordinates: Position
 
 
 class MultiPoint(_GeometryBase):
     """MultiPoint Model"""
 
     type: str = Field("MultiPoint", const=True)
-    coordinates: List[Coordinate]
+    coordinates: List[Position]
 
 
 class LineString(_GeometryBase):
     """LineString Model"""
 
     type: str = Field("LineString", const=True)
-    coordinates: List[Coordinate] = Field(..., min_items=2)
+    coordinates: List[Position] = Field(..., min_items=2)
 
 
 class MultiLineString(_GeometryBase):
     """MultiLineString Model"""
 
     type: str = Field("MultiLineString", const=True)
-    coordinates: List[List[Coordinate]]
+    coordinates: List[List[Position]]
 
 
 class Polygon(_GeometryBase):
     """Polygon Model"""
 
     type: str = Field("Polygon", const=True)
-    coordinates: List[List[Coordinate]]
+    coordinates: List[List[Position]]
 
     @validator("coordinates")
     def check_coordinates(cls, coords):
@@ -70,7 +67,7 @@ class MultiPolygon(_GeometryBase):
     """MultiPolygon Model"""
 
     type: str = Field("MultiPolygon", const=True)
-    coordinates: List[List[List[Coordinate]]]
+    coordinates: List[List[List[Position]]]
 
 
 Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,4 +1,4 @@
-"""utility types for pydantic models"""
+"""Types for geojson_pydantic models"""
 
 from typing import Tuple, Union
 
@@ -7,3 +7,4 @@ BBox = Union[
     Tuple[NumType, NumType, NumType, NumType],  # 2D bbox
     Tuple[NumType, NumType, NumType, NumType, NumType, NumType],  # 3D bbox
 ]
+Position = Union[Tuple[NumType, NumType], Tuple[NumType, NumType, NumType]]


### PR DESCRIPTION
closes #32, closes #19 

This PR does:
- rename `utils.py` to `types.py` **breaking** (I've looked in GitHub and no one is importing `geojson_pydantic.utils` (which only had `types` variables)
- move `Coordinate` type to `types.py` and rename it `Position)  **breaking**
- use absolute imports

cc @geospatial-jeff @drewbo 