### PR TITLE
use pydantic.conlist to define coordinate arrays

### DIFF
--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -2,9 +2,19 @@
 
 from typing import Tuple, Union
 
+from pydantic import conlist
+
 NumType = Union[float, int]
 BBox = Union[
     Tuple[NumType, NumType, NumType, NumType],  # 2D bbox
     Tuple[NumType, NumType, NumType, NumType, NumType, NumType],  # 3D bbox
 ]
 Position = Union[Tuple[NumType, NumType], Tuple[NumType, NumType, NumType]]
+
+# Coordinate arrays
+MultiPointCoords = conlist(Position, min_items=1)
+LineStringCoords = conlist(Position, min_items=2)
+MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
+LinearRing = conlist(Position, min_items=4)
+PolygonCoords = conlist(LinearRing, min_items=1)
+MultiPolygonCoords = conlist(PolygonCoords, min_items=1)


### PR DESCRIPTION
## What I am changing
Use `pydantic.conlist` to type coordinate arrays because it allows specifying `min_items`.  The arguments to `conlist` appear in the auto-generated JSON schema which makes it a better representation of the geojson spec.  Only `LineString` implemented this before this change, now all the geometry types have length constraints on their coordinate arrays.

I noticed this while using `hypothesis-jsonschema` to autogenerate fake data against the JSON schema created by `geojson-pydantic`.  Hypothesis would generate coordinates arrays with invalid number of members (ex. a linear ring with one coordinate).

## How I did it
Because the coordinates members for different geometries build off of eachother I decided to define types for each coordinates type in `types.py` and reference those types in the pydantic models.

## How you can test it
Run pytest!