### PR TITLE
improve test coverage, fix a bug

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -113,10 +113,10 @@ def parse_geometry_obj(obj) -> Geometry:
     """
     if "type" not in obj:
         raise ValidationError(
-            [
-                ErrorWrapper(ValueError("Missing 'type' field in geometry"), "type"),
-                "Geometry",
-            ]
+            errors=[
+                ErrorWrapper(ValueError("Missing 'type' field in geometry"), loc="type")
+            ],
+            model=_GeometryBase,
         )
     if obj["type"] == "Point":
         return Point.parse_obj(obj)

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -92,3 +92,11 @@ def test_feature_collection_generic():
     assert len(fc) == 2
     assert type(fc[0].properties) == GenericProperties
     assert type(fc[0].geometry) == Polygon
+
+
+def test_geo_interface_protocol():
+    class Pointy:
+        __geo_interface__ = {"type": "Point", "coordinates": (0.0, 0.0)}
+
+    feat = Feature(geometry=Pointy())
+    assert feat.geometry.dict() == Pointy.__geo_interface__

--- a/test/test_geometries.py
+++ b/test/test_geometries.py
@@ -187,6 +187,8 @@ def test_parse_geometry_obj_invalid_type():
         parse_geometry_obj({"type": "This type", "obviously": "doesn't exist"})
     with pytest.raises(ValidationError):
         parse_geometry_obj({"type": "", "obviously": "doesn't exist"})
+    with pytest.raises(ValidationError):
+        parse_geometry_obj({})
 
 
 def test_parse_geometry_obj_invalid_point():


### PR DESCRIPTION
## What I am changing
The main goal of this PR was to improve test coverage.  Two cases were not covered:
- Calling `parse_geometry_obj` on an object with no `type` member.
- Creating a geometry from an object implementing the `__geo_interface__` protocol.

Testing the first case revealed a bug that is also fixed in this PR.

## How you can test it
Run pytest!