### PR TITLE
make feature geometry optional

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -9,7 +9,7 @@ from geojson_pydantic.geometries import Geometry
 from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
-Geom = TypeVar("Geom", bound=Geometry)
+Geom = TypeVar("Geom", bound=Optional[Geometry])
 
 
 class Feature(GenericModel, Generic[Geom, Props]):

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -40,6 +40,12 @@ test_feature = {
     "properties": properties,
 }
 
+test_feature_geom_null = {
+    "type": "Feature",
+    "geometry": None,
+    "properties": properties,
+}
+
 
 def test_geometry_collection_iteration():
     """test if feature collection is iterable"""
@@ -100,3 +106,8 @@ def test_geo_interface_protocol():
 
     feat = Feature(geometry=Pointy())
     assert feat.geometry.dict() == Pointy.__geo_interface__
+
+
+def test_feature_with_null_geometry():
+    feature = Feature(**test_feature_geom_null)
+    assert feature.geometry is None


### PR DESCRIPTION
## What I am changing
According to the specs, the geometry attribute of a geojson Feature can be set to `null`. See https://datatracker.ietf.org/doc/html/rfc7946#section-3.2 . But the geometry in the Feature definition in geosjon-pydantic is required.

## How I did it
Wrap the geometry value with an `Optional[]` tag in the feature definition.

## How you can test it
I added a test for this case, but I am not sure if the test is sufficient the way I wrote it. I am not very familiar with pydantic.

## Related Issues
Fixes https://github.com/developmentseed/geojson-pydantic/issues/46

I came across this problem while using stac-fastapi, which uses stac-pydantic, which uses this library. The downstream issues are the following:
https://github.com/stac-utils/stac-pydantic/issues/107
https://github.com/stac-utils/stac-fastapi/issues/350

