### PR TITLE
Update Polygon.from_bounds to create counterclockwise exterior ring

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -76,7 +76,7 @@ class Polygon(_GeometryBase):
         """Create a Polygon geometry from a boundingbox."""
         return cls(
             coordinates=[
-                [[xmin, ymin], [xmin, ymax], [xmax, ymax], [xmax, ymin], [xmin, ymin]]
+                [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]
             ]
         )
 

--- a/test/test_geometries.py
+++ b/test/test_geometries.py
@@ -228,5 +228,5 @@ def test_getitem_geometry_collection(polygon):
 
 def test_polygon_from_bounds():
     """Result from `from_bounds` class method should be the same."""
-    coordinates = [[(1.0, 2.0), (1.0, 4.0), (3.0, 4.0), (3.0, 2.0), (1.0, 2.0)]]
+    coordinates = [[(1.0, 2.0), (3.0, 2.0), (3.0, 4.0), (1.0, 4.0), (1.0, 2.0)]]
     assert Polygon(coordinates=coordinates) == Polygon.from_bounds(1, 2, 3, 4)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
Polygon.from_bounds exterior ring position order.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->

Swapped the coordinates to be counterclockwise, in the code and corresponding test.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->

Review spec linked in issue, since both the code and test changed.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
closes #48 