### PR TITLE
Allow None to be passed for geoms and bboxes on features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Fix optional geometry and bbox fields on `Feature`; allowing users to pass in `None` or even omit either field (author @moradology, https://github.com/developmentseed/geojson-pydantic/pull/56)
 - Fix `Polygon.from_bounds` to respect geojson specification and return counterclockwise linear ring (author @jmfee-usgs, https://github.com/developmentseed/geojson-pydantic/pull/49)
 
 ## [0.3.3] - 2022-03-04

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -9,14 +9,14 @@ from geojson_pydantic.geometries import Geometry
 from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
-Geom = TypeVar("Geom", bound=Geometry)
+Geom = TypeVar("Geom", bound=Optional[Geometry])
 
 
 class Feature(GenericModel, Generic[Geom, Props]):
     """Feature Model"""
 
     type: str = Field("Feature", const=True)
-    geometry: Optional[Geom] = None
+    geometry: Geom = None
     properties: Optional[Props]
     id: Optional[str]
     bbox: Optional[BBox] = None

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -16,10 +16,10 @@ class Feature(GenericModel, Generic[Geom, Props]):
     """Feature Model"""
 
     type: str = Field("Feature", const=True)
-    geometry: Geom
+    geometry: Geom = None
     properties: Optional[Props]
     id: Optional[str]
-    bbox: Optional[BBox]
+    bbox: Optional[BBox] = None
 
     class Config:
         """TODO: document"""

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -9,14 +9,14 @@ from geojson_pydantic.geometries import Geometry
 from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
-Geom = TypeVar("Geom", bound=Optional[Geometry])
+Geom = TypeVar("Geom", bound=Geometry)
 
 
 class Feature(GenericModel, Generic[Geom, Props]):
     """Feature Model"""
 
     type: str = Field("Feature", const=True)
-    geometry: Geom = None
+    geometry: Optional[Geom] = None
     properties: Optional[Props]
     id: Optional[str]
     bbox: Optional[BBox] = None

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extra_reqs = {
 setup(
     name="geojson-pydantic",
     python_requires=">=3.7",
-    description=u"""Pydantic data models for the GeoJSON spec""",
+    description="""Pydantic data models for the GeoJSON spec""",
     long_description=readme,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -29,7 +29,7 @@ setup(
         "Topic :: Scientific/Engineering :: GIS",
     ],
     keywords="geojson pydantic",
-    author=u"Drew Bollinger",
+    author="Drew Bollinger",
     author_email="drew@developmentseed.org",
     url="https://github.com/developmentseed/geojson-pydantic",
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ skip_install = true
 deps =
     wheel
     setuptools
-    click==8.0.4
 commands =
     python setup.py sdist
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ skip_install = true
 deps =
     wheel
     setuptools
+    click==8.0.4
 commands =
     python setup.py sdist
 


### PR DESCRIPTION
This PR addresses #55 by setting the default value of `bbox` and `geometry` on features to `None`