### PR TITLE
Fix: When installing without cache, the install fails because the wheel is not succesfully build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 
 
 .pytest_cache
+
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,42 @@ tag = True
 tag_name = {new_version}
 
 [metadata]
+name = geojson-pydantic
 version = attr: geojson_pydantic.version
+url = https://github.com/developmentseed/geojson-pydantic
+author = Drew Bollinger
+author_email = drew@developmentseed.org
+classifiers =
+    Intended Audience :: Information Technology
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.7
+    Topic :: Scientific/Engineering :: GIS
+license = MIT
+description= Pydantic data models for the GeoJSON spec
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = geojson pydantic
+
+[options]
+install_requires =
+    pydantic
+python_requires = >=3.7
+packages = find:
+
+[options.package_data]
+geojson_pydantic = *.typed
+
+[options.extras_require]
+test = pytest; pytest-cov
+dev = pre-commit
+
+[options.packages.find]
+exclude =
+    tests
 
 [bumpversion:file:geojson_pydantic/__init__.py]
 search = version = "{current_version}"

--- a/setup.py
+++ b/setup.py
@@ -1,41 +1,6 @@
-"""Setup for geojson-pydantic."""
+"""Setup for geojson-pydantic.
+    For the configuration of the metadata and options see setup.cfg."""
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-with open("README.md") as f:
-    readme = f.read()
-
-# Runtime requirements.
-inst_reqs = ["pydantic"]
-
-extra_reqs = {
-    "test": ["pytest", "pytest-cov"],
-    "dev": ["pre-commit"],
-}
-
-setup(
-    name="geojson-pydantic",
-    python_requires=">=3.7",
-    description="""Pydantic data models for the GeoJSON spec""",
-    long_description=readme,
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Intended Audience :: Information Technology",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.7",
-        "Topic :: Scientific/Engineering :: GIS",
-    ],
-    keywords="geojson pydantic",
-    author="Drew Bollinger",
-    author_email="drew@developmentseed.org",
-    url="https://github.com/developmentseed/geojson-pydantic",
-    license="MIT",
-    packages=find_packages(exclude=["tests"]),
-    install_requires=inst_reqs,
-    extras_require=extra_reqs,
-    package_data={"geojson_pydantic": ["*.typed"]},
-)
+if __name__ == "__main__":
+    setup()

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     wheel
     setuptools
 commands =
-    python setup.py sdist
+    python setup.py sdist bdist_wheel
 
 [testenv:release]
 setenv =


### PR DESCRIPTION
The command `pip3 install --no-cache-dir geojson-pydantic~=0.3.4` does not install `pydantic`. The building of the wheel fails because it does not know that version is inside setup.cfg, causing the pip install to fail.
- Add pyproject.toml to fix this issue so that it makes use of setuptools for building.
- Move config from setup.py to setup.cfg so that the config only exists in one place.

Please let me know what your preference is, if you would like to have your config inside the setup.cfg or rather have it as it was before this pull request.