### PR TITLE
Feat/validate json

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -1,6 +1,7 @@
 """pydantic models for GeoJSON Geometry objects."""
 
 import abc
+import json
 from typing import Any, Iterator, List, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
@@ -26,6 +27,20 @@ class _GeometryBase(BaseModel, abc.ABC):
     @property
     def __geo_interface__(self):
         return self.dict()
+
+    @classmethod
+    def validate(cls, value):
+        try:
+            return cls(**json.loads(value))
+        except Exception:
+            pass
+
+        try:
+            return cls(**value.dict())
+        except (AttributeError, ValidationError):
+            pass
+
+        return cls(**value)
 
     @property
     @abc.abstractmethod

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -31,14 +31,12 @@ class _GeometryBase(BaseModel, abc.ABC):
     @classmethod
     def validate(cls, value):
         try:
-            return cls(**json.loads(value))
-        except Exception:
-            pass
-
-        try:
-            return cls(**value.dict())
-        except (AttributeError, ValidationError):
-            pass
+            value = json.loads(value)
+        except TypeError:
+            try:
+                return cls(**value.dict())
+            except (AttributeError, ValidationError):
+                pass
 
         return cls(**value)
 

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -41,9 +41,7 @@ def test_point_valid_coordinates_json(coordinates):
     """
     Two or three number elements as coordinates shold be okay
     """
-    p_json = json.dumps(
-        {'type': 'Point', 'coordinates': coordinates}
-    )
+    p_json = json.dumps({"type": "Point", "coordinates": coordinates})
     p = Point.validate(p_json)
     assert p.type == "Point"
     assert p.coordinates == coordinates
@@ -85,9 +83,7 @@ def test_multi_point_valid_coordinates_json(coordinates):
     """
     Two or three number elements as coordinates shold be okay
     """
-    p_json = json.dumps(
-        {'type': 'MultiPoint', 'coordinates': coordinates}
-    )
+    p_json = json.dumps({"type": "MultiPoint", "coordinates": coordinates})
     p = MultiPoint.validate(p_json)
     assert p.type == "MultiPoint"
     assert p.coordinates == coordinates
@@ -129,9 +125,7 @@ def test_line_string_valid_coordinates_json(coordinates):
     """
     A list of two coordinates or more should be okay
     """
-    linestring_json = json.dumps(
-        {'type': 'LineString', 'coordinates': coordinates}
-    )
+    linestring_json = json.dumps({"type": "LineString", "coordinates": coordinates})
     linestring = LineString.validate(linestring_json)
     assert linestring.type == "LineString"
     assert linestring.coordinates == coordinates
@@ -180,7 +174,7 @@ def test_multi_line_string_valid_coordinates_json(coordinates):
     A list of two coordinates or more should be okay
     """
     multilinestring_json = json.dumps(
-        {'type': 'MultiLineString', 'coordinates': coordinates}
+        {"type": "MultiLineString", "coordinates": coordinates}
     )
     multilinestring = MultiLineString.validate(multilinestring_json)
     assert multilinestring.type == "MultiLineString"
@@ -231,9 +225,7 @@ def test_polygon_valid_coordinates_json(coordinates):
     """
     Should accept lists of linear rings
     """
-    polygon_json = json.dumps(
-        {'type': 'Polygon', 'coordinates': coordinates}
-    )
+    polygon_json = json.dumps({"type": "Polygon", "coordinates": coordinates})
     polygon = Polygon.validate(polygon_json)
     assert polygon.type == "Polygon"
     assert polygon.coordinates == coordinates


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- implement the json validation discussed here: https://github.com/developmentseed/geojson-pydantic/discussions/66

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- add the self validation method for the `_GeometryBase` base class and loads the value.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- f0cc92f918235dc4b5c2ca8f0e45a3f7f1fb913c add few tests for this feature,
- `<GeometryType>.validate(<json geojson formatted>)`, e.g.: `Point.validate('{"type": "Point", "coordinates": (1, 2)}')` return a geojson_pydantic.Point object.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- https://github.com/developmentseed/geojson-pydantic/issues/63
- https://github.com/developmentseed/geojson-pydantic/discussions/66
