### PR TITLE
Fix geo_interface output when bbox is None

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -6,14 +6,14 @@ from typing import Dict, Generic, List, Optional, TypeVar, Union
 from pydantic import Field, ValidationError, validator
 from pydantic.generics import GenericModel
 
-from geojson_pydantic.geometries import Geometry, GeometryCollection
+from geojson_pydantic.geometries import GeoInterfaceMixin, Geometry, GeometryCollection
 from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
 Geom = TypeVar("Geom", bound=Optional[Union[Geometry, GeometryCollection]])
 
 
-class Feature(GenericModel, Generic[Geom, Props]):
+class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """Feature Model"""
 
     type: str = Field("Feature", const=True)
@@ -34,11 +34,6 @@ class Feature(GenericModel, Generic[Geom, Props]):
             return v.__geo_interface__
         return v
 
-    @property
-    def __geo_interface__(self):
-        """GeoJSON-like protocol for geo-spatial (GIS) vector data."""
-        return self.dict()
-
     @classmethod
     def validate(cls, value):
         """Validate input."""
@@ -53,7 +48,7 @@ class Feature(GenericModel, Generic[Geom, Props]):
         return cls(**value)
 
 
-class FeatureCollection(GenericModel, Generic[Geom, Props]):
+class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """FeatureCollection Model"""
 
     type: str = Field("FeatureCollection", const=True)
@@ -71,11 +66,6 @@ class FeatureCollection(GenericModel, Generic[Geom, Props]):
     def __getitem__(self, index):
         """get feature at a given index"""
         return self.features[index]
-
-    @property
-    def __geo_interface__(self):
-        """GeoJSON-like protocol for geo-spatial (GIS) vector data."""
-        return self.dict()
 
     @classmethod
     def validate(cls, value):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -169,6 +169,11 @@ def test_feature_with_null_geometry():
     assert feature.geometry is None
 
 
+def test_feature_geo_interface_with_null_geometry():
+    feature = Feature(**test_feature_geom_null)
+    assert "bbox" not in feature.__geo_interface__
+
+
 def test_validation_from_string():
     """Model.validate() can take string as input."""
     f_string = Feature.validate(json.dumps(test_feature))


### PR DESCRIPTION
The `bbox` key should not be in a geojson object if the bbox is `None`. If the key is present, the value is expected to be a tuple, see https://datatracker.ietf.org/doc/html/rfc7946#section-5

In ths PR, I also moved the `__geo_interface__` into a mixin to reduce code duplication.

There is one design question where I was not sure what is the best:
The bbox check could  be added into the `dict()` method directly. Depending on whether the expected output of `dict` is a valid geojson like dictionary, or the "full" data from the pydantic model. Please advise, I am happy to change that if its considered better to put it into the `dict` method.