### PR TITLE
Fix null bbox handling by making it recursive

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -13,7 +13,7 @@ Props = TypeVar("Props", bound=Dict)
 Geom = TypeVar("Geom", bound=Optional[Union[Geometry, GeometryCollection]])
 
 
-class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
+class Feature(GeoInterfaceMixin, GenericModel, Generic[Geom, Props]):
     """Feature Model"""
 
     type: str = Field("Feature", const=True)
@@ -48,7 +48,7 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
         return cls(**value)
 
 
-class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
+class FeatureCollection(GeoInterfaceMixin, GenericModel, Generic[Geom, Props]):
     """FeatureCollection Model"""
 
     type: str = Field("FeatureCollection", const=True)

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -22,16 +22,20 @@ from geojson_pydantic.types import (
 class GeoInterfaceMixin:
     """Geo interface mixin class"""
 
-    @property
-    def __geo_interface__(self):
-        """GeoJSON-like protocol for geo-spatial (GIS) vector data."""
-        result = self.dict()
+    def dict(self, *args, **kwargs):
+        """Dict method that removes null bbox values"""
+        result = super().dict(*args, **kwargs)
         if "bbox" in result and result["bbox"] is None:
             del result["bbox"]
         return result
 
+    @property
+    def __geo_interface__(self):
+        """GeoJSON-like protocol for geo-spatial (GIS) vector data."""
+        return self.dict()
 
-class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
+
+class _GeometryBase(GeoInterfaceMixin, BaseModel, abc.ABC):
     """Base class for geometry models"""
 
     coordinates: Any  # will be constrained in child classes
@@ -214,7 +218,7 @@ class MultiPolygon(_GeometryBase):
 Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]
 
 
-class GeometryCollection(BaseModel, GeoInterfaceMixin):
+class GeometryCollection(GeoInterfaceMixin, BaseModel):
     """GeometryCollection Model"""
 
     type: str = Field("GeometryCollection", const=True)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -46,6 +46,7 @@ test_feature = {
     "type": "Feature",
     "geometry": polygon,
     "properties": properties,
+    "bbox": [13.38272, 52.46385, 13.42786, 52.48445],
 }
 
 test_feature_geom_null = {
@@ -172,6 +173,13 @@ def test_feature_with_null_geometry():
 def test_feature_geo_interface_with_null_geometry():
     feature = Feature(**test_feature_geom_null)
     assert "bbox" not in feature.__geo_interface__
+
+
+def test_feature_collection_geo_interface_with_null_geometry():
+    fc = FeatureCollection(features=[test_feature_geom_null, test_feature])
+    assert "bbox" not in fc.__geo_interface__
+    assert "bbox" not in fc.__geo_interface__["features"][0]
+    assert "bbox" in fc.__geo_interface__["features"][1]
 
 
 def test_validation_from_string():


### PR DESCRIPTION
The previous implementation did not remove empty bbox values of child objects. The problem is that the `__geo_interface__` method is not recursive, for child objects such as features of a FeatureCollection. So a feature in a feature collection would continue having null bbox values.

This is why I propose to move the bbox removal into the `dict` method. The dict method is automatically called recursively on the members and will ensure compliance through that.

We previously discarded this `dict` based option in #77. The alternative here is to "manually walk" though the child members and remove bbox  attributes that are None. But I think that would lead to not very readable code without much added value. What do you think?


