### PR TITLE
Switch WKT to use type over class name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.5.0] - TBD
 
+## Fixed
+
+- Derive WKT type from Geometry's type instead of class name (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/81)
+
 ### Changed
 
 - Remove `NumType` and use `float` throughout (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/83)

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -34,7 +34,9 @@ class GeoInterfaceMixin:
 class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     """Base class for geometry models"""
 
-    coordinates: Any  # will be constrained in child classes
+    # will be constrained in child classes
+    type: str
+    coordinates: Any
 
     @classmethod
     def validate(cls, value):
@@ -62,7 +64,7 @@ class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     @property
     def _wkt_type(self) -> str:
         """Return the WKT name of the geometry."""
-        return self.__class__.__name__.upper()
+        return self.type.upper()
 
     @property
     def wkt(self) -> str:
@@ -235,7 +237,7 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
     @property
     def _wkt_type(self) -> str:
         """Return the WKT name of the geometry."""
-        return self.__class__.__name__.upper()
+        return self.type.upper()
 
     @property
     def _wkt_coordinates(self) -> str:

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -33,7 +33,6 @@ class GeoInterfaceMixin:
 class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     """Base class for geometry models"""
 
-    # will be constrained in child classes
     type: str
     coordinates: Any
 

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -471,3 +471,14 @@ def test_polygon_from_bounds():
     """Result from `from_bounds` class method should be the same."""
     coordinates = [[(1.0, 2.0), (3.0, 2.0), (3.0, 4.0), (1.0, 4.0), (1.0, 2.0)]]
     assert Polygon(coordinates=coordinates) == Polygon.from_bounds(1.0, 2.0, 3.0, 4.0)
+
+
+def test_wkt_name():
+    """Make sure WKT name is derived from geometry Type."""
+
+    class PointType(Point):
+        ...
+
+    assert (
+        PointType(coordinates=(1.01, 2.01)).wkt == Point(coordinates=(1.01, 2.01)).wkt
+    )


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Make the `_wkt_type` function work when the class is inherited from.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Switched the `_wkt_type` function to use the `type`. Since a "type" MUST exist in the spec, and it cannot be modified. It will always match the WKT type unlike the class name.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Tests still run properly. And now this works:
```python
from geojson_pydantic import Point
class PointType(Point):
    ...

print(PointType(coordinates=[123, 123]).wkt)
# POINT (123.0 123.0)
```

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Fixes: developmentseed/geojson-pydantic#78
