### PR TITLE
Remove NumType and use float throughout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0] - TBD
+
+### Changed
+
+- Remove `NumType` and use `float` throughout (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/83)
+
 ## [0.4.3] - 2022-07-18
 
 ### Fixed
@@ -201,7 +207,8 @@ Although the type file was added in `0.2.0` it wasn't included in the distribute
 ### Added
 - Initial Release
 
-[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/0.4.3...HEAD
+[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/developmentseed/geojson-pydantic/compare/0.4.3...0.5.0
 [0.4.3]: https://github.com/developmentseed/geojson-pydantic/compare/0.4.2...0.4.3
 [0.4.2]: https://github.com/developmentseed/geojson-pydantic/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/developmentseed/geojson-pydantic/compare/0.4.0...0.4.1

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -13,7 +13,6 @@ from geojson_pydantic.types import (
     MultiLineStringCoords,
     MultiPointCoords,
     MultiPolygonCoords,
-    NumType,
     PolygonCoords,
     Position,
 )
@@ -185,7 +184,7 @@ class Polygon(_GeometryBase):
 
     @classmethod
     def from_bounds(
-        cls, xmin: NumType, ymin: NumType, xmax: NumType, ymax: NumType
+        cls, xmin: float, ymin: float, xmax: float, ymax: float
     ) -> "Polygon":
         """Create a Polygon geometry from a boundingbox."""
         return cls(

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -4,12 +4,11 @@ from typing import Tuple, Union
 
 from pydantic import conlist
 
-NumType = Union[float, int]
 BBox = Union[
-    Tuple[NumType, NumType, NumType, NumType],  # 2D bbox
-    Tuple[NumType, NumType, NumType, NumType, NumType, NumType],  # 3D bbox
+    Tuple[float, float, float, float],  # 2D bbox
+    Tuple[float, float, float, float, float, float],  # 3D bbox
 ]
-Position = Union[Tuple[NumType, NumType], Tuple[NumType, NumType, NumType]]
+Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays
 MultiPointCoords = conlist(Position, min_items=1)


### PR DESCRIPTION
I believe this to be more correct based on the spec.

Updated all the tests due to the automatic conversion to float making `(1, 2) != (1.0, 2.0)`. 

Tweaked `assert_wkt_equivalence` so it doesn't fail when using a number such as `1.01`. 

Discussion: developmentseed/geojson-pydantic#82