### PR TITLE
Updates and cleans up typing.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.4.2
+    rev: 5.10.1
     hooks:
       - id: isort
         language_version: python
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python
@@ -26,7 +26,10 @@ repos:
           - toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.960
+    rev: v0.971
     hooks:
       - id: mypy
         language_version: python
+        files: geojson_pydantic/.*\.py
+        additional_dependencies:
+          - pydantic==1.9.1

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -1,23 +1,23 @@
 """pydantic models for GeoJSON Feature objects."""
 
-import json
-from typing import Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from pydantic import Field, ValidationError, validator
+from pydantic import BaseModel, validator
 from pydantic.generics import GenericModel
+from typing_extensions import Literal
 
 from geojson_pydantic.geometries import GeoInterfaceMixin, Geometry, GeometryCollection
 from geojson_pydantic.types import BBox
 
-Props = TypeVar("Props", bound=Dict)
-Geom = TypeVar("Geom", bound=Optional[Union[Geometry, GeometryCollection]])
+Props = TypeVar("Props", bound=Union[Dict, BaseModel])
+Geom = TypeVar("Geom", bound=Union[Geometry, GeometryCollection])
 
 
 class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """Feature Model"""
 
-    type: str = Field("Feature", const=True)
-    geometry: Geom = None
+    type: Literal["Feature"] = "Feature"
+    geometry: Optional[Geom] = None
     properties: Optional[Props]
     id: Optional[str]
     bbox: Optional[BBox] = None
@@ -28,54 +28,28 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
         use_enum_values = True
 
     @validator("geometry", pre=True, always=True)
-    def set_geometry(cls, v):
-        """set geometry from geo interface or input"""
+    def set_geometry(cls, v: Any) -> Any:
+        """Set geometry from geo interface or input"""
         if hasattr(v, "__geo_interface__"):
             return v.__geo_interface__
         return v
-
-    @classmethod
-    def validate(cls, value):
-        """Validate input."""
-        try:
-            value = json.loads(value)
-        except TypeError:
-            try:
-                return cls(**value.dict())
-            except (AttributeError, ValidationError):
-                pass
-
-        return cls(**value)
 
 
 class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """FeatureCollection Model"""
 
-    type: str = Field("FeatureCollection", const=True)
+    type: Literal["FeatureCollection"] = "FeatureCollection"
     features: List[Feature[Geom, Props]]
-    bbox: Optional[BBox]
+    bbox: Optional[BBox] = None
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[Feature]:  # type: ignore [override]
         """iterate over features"""
         return iter(self.features)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """return features length"""
         return len(self.features)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Feature:
         """get feature at a given index"""
         return self.features[index]
-
-    @classmethod
-    def validate(cls, value):
-        """Validate input."""
-        try:
-            value = json.loads(value)
-        except TypeError:
-            try:
-                return cls(**value.dict())
-            except (AttributeError, ValidationError):
-                pass
-
-        return cls(**value)

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,6 +1,6 @@
 """Types for geojson_pydantic models"""
 
-from typing import Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 from pydantic import conlist
 
@@ -11,9 +11,19 @@ BBox = Union[
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays
-MultiPointCoords = conlist(Position, min_items=1)
-LineStringCoords = conlist(Position, min_items=2)
-MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
-LinearRing = conlist(Position, min_items=4)
-PolygonCoords = conlist(LinearRing, min_items=1)
-MultiPolygonCoords = conlist(PolygonCoords, min_items=1)
+if TYPE_CHECKING:
+    # Mypy will not execute functions, so use List for type checking
+    MultiPointCoords = List[Position]
+    LineStringCoords = List[Position]
+    MultiLineStringCoords = List[LineStringCoords]
+    LinearRing = List[Position]
+    PolygonCoords = List[LinearRing]
+    MultiPolygonCoords = List[PolygonCoords]
+else:
+    # Pydantic will use the real types from here
+    MultiPointCoords = conlist(Position, min_items=1)
+    LineStringCoords = conlist(Position, min_items=2)
+    MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
+    LinearRing = conlist(Position, min_items=4)
+    PolygonCoords = conlist(LinearRing, min_items=1)
+    MultiPolygonCoords = conlist(PolygonCoords, min_items=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,16 @@ known_third_party = ["pydantic"]
 default_section = "THIRDPARTY"
 
 [tool.mypy]
-no_strict_optional = true
+plugins = "pydantic.mypy"
+
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+
+show_error_codes = true
 
 [tool.pydocstyle]
 select = "D1"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,4 +1,3 @@
-import json
 from random import randint
 from typing import Dict
 from uuid import uuid4
@@ -172,17 +171,3 @@ def test_feature_with_null_geometry():
 def test_feature_geo_interface_with_null_geometry():
     feature = Feature(**test_feature_geom_null)
     assert "bbox" not in feature.__geo_interface__
-
-
-def test_validation_from_string():
-    """Model.validate() can take string as input."""
-    f_string = Feature.validate(json.dumps(test_feature))
-    f = Feature.validate(test_feature)
-    assert f.json() == f_string.json()
-
-    fc = FeatureCollection(features=[test_feature, test_feature]).dict(
-        exclude_none=True
-    )
-    f_string = FeatureCollection.validate(json.dumps(fc))
-    f = FeatureCollection.validate(fc)
-    assert f.json() == f_string.json()

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import pytest
@@ -31,19 +30,6 @@ def test_point_valid_coordinates(coordinates):
     Two or three number elements as coordinates shold be okay
     """
     p = Point(coordinates=coordinates)
-    assert p.type == "Point"
-    assert p.coordinates == coordinates
-    assert hasattr(p, "__geo_interface__")
-    assert_wkt_equivalence(p)
-
-
-@pytest.mark.parametrize("coordinates", [(1.01, 2.01), (1.0, 2.0, 3.0), (1.0, 2.0)])
-def test_point_valid_coordinates_json(coordinates):
-    """
-    Two or three number elements as coordinates shold be okay
-    """
-    p_json = json.dumps({"type": "Point", "coordinates": coordinates})
-    p = Point.validate(p_json)
     assert p.type == "Point"
     assert p.coordinates == coordinates
     assert hasattr(p, "__geo_interface__")
@@ -83,27 +69,6 @@ def test_multi_point_valid_coordinates(coordinates):
 
 @pytest.mark.parametrize(
     "coordinates",
-    [
-        [(1.0, 2.0)],
-        [(1.0, 2.0), (1.0, 2.0)],
-        [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0)],
-        [(1.0, 2.0), (1.0, 2.0)],
-    ],
-)
-def test_multi_point_valid_coordinates_json(coordinates):
-    """
-    Two or three number elements as coordinates shold be okay
-    """
-    p_json = json.dumps({"type": "MultiPoint", "coordinates": coordinates})
-    p = MultiPoint.validate(p_json)
-    assert p.type == "MultiPoint"
-    assert p.coordinates == coordinates
-    assert hasattr(p, "__geo_interface__")
-    assert_wkt_equivalence(p)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
     [[(1.0,)], [(1.0, 2.0, 3.0, 4.0)], ["Foo"], [(None, 2.0)], [(1.0, (2.0,))]],
 )
 def test_multi_point_invalid_coordinates(coordinates):
@@ -127,26 +92,6 @@ def test_line_string_valid_coordinates(coordinates):
     A list of two coordinates or more should be okay
     """
     linestring = LineString(coordinates=coordinates)
-    assert linestring.type == "LineString"
-    assert linestring.coordinates == coordinates
-    assert hasattr(linestring, "__geo_interface__")
-    assert_wkt_equivalence(linestring)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
-    [
-        [(1.0, 2.0), (3.0, 4.0)],
-        [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)],
-        [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
-    ],
-)
-def test_line_string_valid_coordinates_json(coordinates):
-    """
-    A list of two coordinates or more should be okay
-    """
-    linestring_json = json.dumps({"type": "LineString", "coordinates": coordinates})
-    linestring = LineString.validate(linestring_json)
     assert linestring.type == "LineString"
     assert linestring.coordinates == coordinates
     assert hasattr(linestring, "__geo_interface__")
@@ -182,28 +127,6 @@ def test_multi_line_string_valid_coordinates(coordinates):
 
 
 @pytest.mark.parametrize(
-    "coordinates",
-    [
-        [[(1.0, 2.0), (3.0, 4.0)]],
-        [[(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
-        [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]],
-    ],
-)
-def test_multi_line_string_valid_coordinates_json(coordinates):
-    """
-    A list of two coordinates or more should be okay
-    """
-    multilinestring_json = json.dumps(
-        {"type": "MultiLineString", "coordinates": coordinates}
-    )
-    multilinestring = MultiLineString.validate(multilinestring_json)
-    assert multilinestring.type == "MultiLineString"
-    assert multilinestring.coordinates == coordinates
-    assert hasattr(multilinestring, "__geo_interface__")
-    assert_wkt_equivalence(multilinestring)
-
-
-@pytest.mark.parametrize(
     "coordinates", [[None], ["Foo"], [[]], [[(1.0, 2.0)]], [["Foo", "Bar"]]]
 )
 def test_multi_line_string_invalid_coordinates(coordinates):
@@ -226,27 +149,6 @@ def test_polygon_valid_coordinates(coordinates):
     Should accept lists of linear rings
     """
     polygon = Polygon(coordinates=coordinates)
-    assert polygon.type == "Polygon"
-    assert polygon.coordinates == coordinates
-    assert hasattr(polygon, "__geo_interface__")
-    assert polygon.exterior == coordinates[0]
-    assert not list(polygon.interiors)
-    assert_wkt_equivalence(polygon)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
-    [
-        [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]],
-        [[(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
-    ],
-)
-def test_polygon_valid_coordinates_json(coordinates):
-    """
-    Should accept lists of linear rings
-    """
-    polygon_json = json.dumps({"type": "Polygon", "coordinates": coordinates})
-    polygon = Polygon.validate(polygon_json)
     assert polygon.type == "Polygon"
     assert polygon.coordinates == coordinates
     assert hasattr(polygon, "__geo_interface__")


### PR DESCRIPTION
- Updated pre-commit versions.
- Adds a few mypy checks.
- Adds Protocol for GeoInterfaceMixin.
- Adds "type" to _GeometryBase.
- Removes validate functions per developmentseed/geojson-pydantic/#66
additional discussion.
- Removes tests for validate function.
- Moves to Literal for exact values.
- Removes Unneeded LinearRingGeom, validation already happens on Polygon.
- Uses Annotated Type for Geometry.
- Adds types to additional functions.
- Uses `if TYPE_CHECKING` in types.py to keep things happier.
- Pre-commit doesn't run mypy on tests now, as they intentionally do bad
things.

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
