### PR TITLE
Cleanup Types to make Mypy and Pyright happier.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.4.2
+    rev: 5.10.1
     hooks:
       - id: isort
         language_version: python
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python
@@ -26,7 +26,15 @@ repos:
           - toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.960
+    rev: v0.971
     hooks:
       - id: mypy
         language_version: python
+        # No reason to run if only tests have changed. They intentionally break typing.
+        exclude: tests/.*
+        # Pass mypy the entire folder because a change in one file can break others. 
+        args: [--config-file=pyproject.toml, geojson_pydantic/]
+        # Don't pass it the individual filenames because it is already doing the whole folder.
+        pass_filenames: false
+        additional_dependencies:
+          - pydantic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.5.0] - TBD
 
-## Fixed
+### Fixed
 
 - Derive WKT type from Geometry's type instead of class name (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/81)
 
 ### Changed
 
-- Remove `NumType` and use `float` throughout (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/83)
+- Replace `NumType` with `float` throughout (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/83)
 - `__geo_interface__` definition to not use pydantic `BaseModel.dict()` method and better match the specification
+- Adjusted mypy configuration and updated type definitions to satisfy all rules (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/87)
+- Updated pre-commit config to run mypy on the whole library instead of individual changed files.
+- Defaults are more explicit. This keeps pyright from thinking they are required.
+
+### Removed
+
+- Remove `validate` classmethods used to implicitly load json strings (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/88)
 
 ## [0.4.3] - 2022-07-18
 

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -1,16 +1,17 @@
 """pydantic models for GeoJSON Feature objects."""
 
 import json
-from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterator, List, Optional, Type, TypeVar, Union
 
-from pydantic import Field, ValidationError, validator
+from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.generics import GenericModel
 
 from geojson_pydantic.geometries import GeoInterfaceMixin, Geometry, GeometryCollection
 from geojson_pydantic.types import BBox
 
-Props = TypeVar("Props", bound=Dict)
+Props = TypeVar("Props", bound=Union[Dict[str, Any], BaseModel])
 Geom = TypeVar("Geom", bound=Union[Geometry, GeometryCollection])
+F = TypeVar("F", bound="Feature")
 
 
 class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
@@ -35,7 +36,7 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
         return geometry
 
     @classmethod
-    def validate(cls, value: Any) -> "Feature":
+    def validate(cls: Type[F], value: Any) -> F:
         """Validate input."""
         try:
             value = json.loads(value)
@@ -46,6 +47,9 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
                 pass
 
         return cls(**value)
+
+
+FC = TypeVar("FC", bound="FeatureCollection")
 
 
 class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
@@ -68,7 +72,7 @@ class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
         return self.features[index]
 
     @classmethod
-    def validate(cls, value: Any) -> "FeatureCollection":
+    def validate(cls: Type[FC], value: Any) -> FC:
         """Validate input."""
         try:
             value = json.loads(value)

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -1,7 +1,7 @@
 """pydantic models for GeoJSON Feature objects."""
 
 import json
-from typing import Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, Iterator, List, Optional, TypeVar, Union
 
 from pydantic import Field, ValidationError, validator
 from pydantic.generics import GenericModel
@@ -10,16 +10,16 @@ from geojson_pydantic.geometries import GeoInterfaceMixin, Geometry, GeometryCol
 from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Dict)
-Geom = TypeVar("Geom", bound=Optional[Union[Geometry, GeometryCollection]])
+Geom = TypeVar("Geom", bound=Union[Geometry, GeometryCollection])
 
 
 class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """Feature Model"""
 
-    type: str = Field("Feature", const=True)
-    geometry: Geom = None
-    properties: Optional[Props]
-    id: Optional[str]
+    type: str = Field(default="Feature", const=True)
+    geometry: Optional[Geom] = None
+    properties: Optional[Props] = None
+    id: Optional[str] = None
     bbox: Optional[BBox] = None
 
     class Config:
@@ -28,14 +28,14 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
         use_enum_values = True
 
     @validator("geometry", pre=True, always=True)
-    def set_geometry(cls, v):
+    def set_geometry(cls, geometry: Any) -> Any:
         """set geometry from geo interface or input"""
-        if hasattr(v, "__geo_interface__"):
-            return v.__geo_interface__
-        return v
+        if hasattr(geometry, "__geo_interface__"):
+            return geometry.__geo_interface__
+        return geometry
 
     @classmethod
-    def validate(cls, value):
+    def validate(cls, value: Any) -> "Feature":
         """Validate input."""
         try:
             value = json.loads(value)
@@ -51,24 +51,24 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
 class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """FeatureCollection Model"""
 
-    type: str = Field("FeatureCollection", const=True)
+    type: str = Field(default="FeatureCollection", const=True)
     features: List[Feature[Geom, Props]]
-    bbox: Optional[BBox]
+    bbox: Optional[BBox] = None
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Feature]:  # type: ignore [override]
         """iterate over features"""
         return iter(self.features)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """return features length"""
         return len(self.features)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Feature:
         """get feature at a given index"""
         return self.features[index]
 
     @classmethod
-    def validate(cls, value):
+    def validate(cls, value: Any) -> "FeatureCollection":
         """Validate input."""
         try:
             value = json.loads(value)

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -2,7 +2,7 @@
 
 import abc
 import json
-from typing import Any, Iterator, List, Union
+from typing import Any, Dict, Iterator, List, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
@@ -22,9 +22,9 @@ class GeoInterfaceMixin:
     """Geo interface mixin class"""
 
     @property
-    def __geo_interface__(self):
+    def __geo_interface__(self) -> Dict[str, Any]:
         """GeoJSON-like protocol for geo-spatial (GIS) vector data."""
-        result = self.dict()
+        result = self.dict()  # type: ignore [attr-defined]
         if "bbox" in result and result["bbox"] is None:
             del result["bbox"]
         return result
@@ -37,7 +37,7 @@ class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     coordinates: Any
 
     @classmethod
-    def validate(cls, value):
+    def validate(cls, value: Any) -> "_GeometryBase":
         try:
             value = json.loads(value)
         except TypeError:
@@ -73,7 +73,7 @@ class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
 class Point(_GeometryBase):
     """Point Model"""
 
-    type: str = Field("Point", const=True)
+    type: str = Field(default="Point", const=True)
     coordinates: Position
 
     @property
@@ -88,7 +88,7 @@ class Point(_GeometryBase):
 class MultiPoint(_GeometryBase):
     """MultiPoint Model"""
 
-    type: str = Field("MultiPoint", const=True)
+    type: str = Field(default="MultiPoint", const=True)
     coordinates: MultiPointCoords
 
     @property
@@ -104,7 +104,7 @@ class MultiPoint(_GeometryBase):
 class LineString(_GeometryBase):
     """LineString Model"""
 
-    type: str = Field("LineString", const=True)
+    type: str = Field(default="LineString", const=True)
     coordinates: LineStringCoords
 
     @property
@@ -120,7 +120,7 @@ class LineString(_GeometryBase):
 class MultiLineString(_GeometryBase):
     """MultiLineString Model"""
 
-    type: str = Field("MultiLineString", const=True)
+    type: str = Field(default="MultiLineString", const=True)
     coordinates: MultiLineStringCoords
 
     @property
@@ -137,27 +137,27 @@ class LinearRingGeom(LineString):
     """LinearRing model."""
 
     @validator("coordinates")
-    def check_closure(cls, values):
+    def check_closure(cls, coordinates: List) -> List:
         """Validate that LinearRing is closed (first and last coordinate are the same)."""
-        if values[-1] != values[0]:
+        if coordinates[-1] != coordinates[0]:
             raise ValueError("LinearRing must have the same start and end coordinates")
 
-        return values
+        return coordinates
 
 
 class Polygon(_GeometryBase):
     """Polygon Model"""
 
-    type: str = Field("Polygon", const=True)
+    type: str = Field(default="Polygon", const=True)
     coordinates: PolygonCoords
 
     @validator("coordinates")
-    def check_closure(cls, polygon):
+    def check_closure(cls, coordinates: List) -> List:
         """Validate that Polygon is closed (first and last coordinate are the same)."""
-        if any([ring[-1] != ring[0] for ring in polygon]):
+        if any([ring[-1] != ring[0] for ring in coordinates]):
             raise ValueError("All linear rings have the same start and end coordinates")
 
-        return polygon
+        return coordinates
 
     @property
     def exterior(self) -> LinearRing:
@@ -190,7 +190,7 @@ class Polygon(_GeometryBase):
         """Create a Polygon geometry from a boundingbox."""
         return cls(
             coordinates=[
-                [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]
+                [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax), (xmin, ymin)]
             ]
         )
 
@@ -198,7 +198,7 @@ class Polygon(_GeometryBase):
 class MultiPolygon(_GeometryBase):
     """MultiPolygon Model"""
 
-    type: str = Field("MultiPolygon", const=True)
+    type: str = Field(default="MultiPolygon", const=True)
     coordinates: MultiPolygonCoords
 
     @property
@@ -217,18 +217,18 @@ Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiP
 class GeometryCollection(BaseModel, GeoInterfaceMixin):
     """GeometryCollection Model"""
 
-    type: str = Field("GeometryCollection", const=True)
+    type: str = Field(default="GeometryCollection", const=True)
     geometries: List[Geometry]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Geometry]:  # type: ignore [override]
         """iterate over geometries"""
         return iter(self.geometries)
 
-    def __len__(self):
+    def __len__(self) -> int:
         """return geometries length"""
         return len(self.geometries)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Geometry:
         """get geometry at a given index"""
         return self.geometries[index]
 
@@ -248,7 +248,7 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
         return f"{self._wkt_type} ({self._wkt_coordinates})"
 
 
-def parse_geometry_obj(obj) -> Geometry:
+def parse_geometry_obj(obj: Any) -> Geometry:
     """
     `obj` is an object that is supposed to represent a GeoJSON geometry. This method returns the
     reads the `"type"` field and returns the correct pydantic Geometry model.
@@ -273,5 +273,6 @@ def parse_geometry_obj(obj) -> Geometry:
     elif obj["type"] == "MultiPolygon":
         return MultiPolygon.parse_obj(obj)
     raise ValidationError(
-        [ErrorWrapper(ValueError("Unknown type"), "type")], "Geometry"
+        errors=[ErrorWrapper(ValueError("Unknown type"), loc="type")],
+        model=_GeometryBase,
     )

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -2,7 +2,7 @@
 
 import abc
 import json
-from typing import Any, Dict, Iterator, List, Union
+from typing import Any, Dict, Iterator, List, Type, TypeVar, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
@@ -30,6 +30,9 @@ class GeoInterfaceMixin:
         return result
 
 
+T = TypeVar("T", bound="_GeometryBase")
+
+
 class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     """Base class for geometry models"""
 
@@ -37,7 +40,7 @@ class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
     coordinates: Any
 
     @classmethod
-    def validate(cls, value: Any) -> "_GeometryBase":
+    def validate(cls: Type[T], value: Any) -> T:
         try:
             value = json.loads(value)
         except TypeError:

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,6 +1,6 @@
 """Types for geojson_pydantic models"""
 
-from typing import Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 from pydantic import conlist
 
@@ -11,9 +11,18 @@ BBox = Union[
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays
-MultiPointCoords = conlist(Position, min_items=1)
-LineStringCoords = conlist(Position, min_items=2)
-MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
-LinearRing = conlist(Position, min_items=4)
-PolygonCoords = conlist(LinearRing, min_items=1)
-MultiPolygonCoords = conlist(PolygonCoords, min_items=1)
+
+if TYPE_CHECKING:
+    MultiPointCoords = List[Position]
+    LineStringCoords = List[Position]
+    MultiLineStringCoords = List[List[Position]]
+    LinearRing = List[Position]
+    PolygonCoords = List[List[Position]]
+    MultiPolygonCoords = List[List[List[Position]]]
+else:
+    MultiPointCoords = conlist(Position, min_items=1)
+    LineStringCoords = conlist(Position, min_items=2)
+    MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
+    LinearRing = conlist(Position, min_items=4)
+    PolygonCoords = conlist(LinearRing, min_items=1)
+    MultiPolygonCoords = conlist(PolygonCoords, min_items=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ known_third_party = ["pydantic"]
 default_section = "THIRDPARTY"
 
 [tool.mypy]
+plugins = [
+  "pydantic.mypy"
+]
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
@@ -59,6 +62,9 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = true
 show_error_codes = true
+
+[tool.pydantic-mypy]
+warn_untyped_fields = true
 
 [tool.pydocstyle]
 select = "D1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,13 @@ known_third_party = ["pydantic"]
 default_section = "THIRDPARTY"
 
 [tool.mypy]
-no_strict_optional = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+show_error_codes = true
 
 [tool.pydocstyle]
 select = "D1"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,6 +1,6 @@
 import json
 from random import randint
-from typing import Dict
+from typing import Any, Dict
 from uuid import uuid4
 
 import pytest
@@ -21,13 +21,13 @@ class GenericProperties(BaseModel):
     size: int
 
 
-properties = {
+properties: Dict[str, Any] = {
     "id": str(uuid4()),
     "description": str(uuid4()),
     "size": randint(0, 1000),
 }
 
-polygon = {
+polygon: Dict[str, Any] = {
     "type": "Polygon",
     "coordinates": [
         [
@@ -40,21 +40,24 @@ polygon = {
     ],
 }
 
-geom_collection = {"type": "GeometryCollection", "geometries": [polygon, polygon]}
+geom_collection: Dict[str, Any] = {
+    "type": "GeometryCollection",
+    "geometries": [polygon, polygon],
+}
 
-test_feature = {
+test_feature: Dict[str, Any] = {
     "type": "Feature",
     "geometry": polygon,
     "properties": properties,
 }
 
-test_feature_geom_null = {
+test_feature_geom_null: Dict[str, Any] = {
     "type": "Feature",
     "geometry": None,
     "properties": properties,
 }
 
-test_feature_geometry_collection = {
+test_feature_geometry_collection: Dict[str, Any] = {
     "type": "Feature",
     "geometry": geom_collection,
     "properties": properties,

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -1,5 +1,6 @@
 import json
 import re
+from typing import Union
 
 import pytest
 from pydantic import ValidationError
@@ -18,7 +19,7 @@ from geojson_pydantic.geometries import (
 )
 
 
-def assert_wkt_equivalence(geom: Geometry):
+def assert_wkt_equivalence(geom: Union[Geometry, GeometryCollection]):
     """Assert WKT equivalence with Shapely."""
     # Remove any trailing `.0` to match Shapely format
     clean_wkt = re.sub(r"\.0(\D)", r"\1", geom.wkt)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Adjusted typing throughout the package to be more complete and accurate.
- Updated pre-commit to run mypy on the whole package vs individual files.
- Clean up defaults so `type` isn't treaded as required and `Optional` all have default `None` and aren't considered required either. 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Tweaked mypy to use pydantic plugin and have slightly stricter rules.
- Tweaked types until mypy no longer threw errors.
- Tweaked types until pyright was no longer throwing errors in the module. 
- Validated typing in the tests so there were no major complaints. 

Hopefully this is reasonable. It does touch a bunch of lines but I tried to avoid anything other than types.  

I would have preferred to not do the `if TYPE_CHECKING` in `types.py` but the alternative was `Annotated` and I found a bug in pydantic that prevents nested annotated lists from working. Will keep an eye on https://github.com/samuelcolvin/pydantic/issues/4333 and could switch when it is fixed. 