### PR TITLE
Remove validate function to load from a string.

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -1,9 +1,8 @@
 """pydantic models for GeoJSON Feature objects."""
 
-import json
 from typing import Dict, Generic, List, Optional, TypeVar, Union
 
-from pydantic import Field, ValidationError, validator
+from pydantic import Field, validator
 from pydantic.generics import GenericModel
 
 from geojson_pydantic.geometries import GeoInterfaceMixin, Geometry, GeometryCollection
@@ -34,19 +33,6 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
             return v.__geo_interface__
         return v
 
-    @classmethod
-    def validate(cls, value):
-        """Validate input."""
-        try:
-            value = json.loads(value)
-        except TypeError:
-            try:
-                return cls(**value.dict())
-            except (AttributeError, ValidationError):
-                pass
-
-        return cls(**value)
-
 
 class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     """FeatureCollection Model"""
@@ -66,16 +52,3 @@ class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     def __getitem__(self, index):
         """get feature at a given index"""
         return self.features[index]
-
-    @classmethod
-    def validate(cls, value):
-        """Validate input."""
-        try:
-            value = json.loads(value)
-        except TypeError:
-            try:
-                return cls(**value.dict())
-            except (AttributeError, ValidationError):
-                pass
-
-        return cls(**value)

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -1,7 +1,6 @@
 """pydantic models for GeoJSON Geometry objects."""
 
 import abc
-import json
 from typing import Any, Iterator, List, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
@@ -35,18 +34,6 @@ class _GeometryBase(BaseModel, GeoInterfaceMixin, abc.ABC):
 
     type: str
     coordinates: Any
-
-    @classmethod
-    def validate(cls, value):
-        try:
-            value = json.loads(value)
-        except TypeError:
-            try:
-                return cls(**value.dict())
-            except (AttributeError, ValidationError):
-                pass
-
-        return cls(**value)
 
     @property
     @abc.abstractmethod

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,4 +1,3 @@
-import json
 from random import randint
 from typing import Dict
 from uuid import uuid4
@@ -172,17 +171,3 @@ def test_feature_with_null_geometry():
 def test_feature_geo_interface_with_null_geometry():
     feature = Feature(**test_feature_geom_null)
     assert "bbox" not in feature.__geo_interface__
-
-
-def test_validation_from_string():
-    """Model.validate() can take string as input."""
-    f_string = Feature.validate(json.dumps(test_feature))
-    f = Feature.validate(test_feature)
-    assert f.json() == f_string.json()
-
-    fc = FeatureCollection(features=[test_feature, test_feature]).dict(
-        exclude_none=True
-    )
-    f_string = FeatureCollection.validate(json.dumps(fc))
-    f = FeatureCollection.validate(fc)
-    assert f.json() == f_string.json()

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import pytest
@@ -31,19 +30,6 @@ def test_point_valid_coordinates(coordinates):
     Two or three number elements as coordinates shold be okay
     """
     p = Point(coordinates=coordinates)
-    assert p.type == "Point"
-    assert p.coordinates == coordinates
-    assert hasattr(p, "__geo_interface__")
-    assert_wkt_equivalence(p)
-
-
-@pytest.mark.parametrize("coordinates", [(1.01, 2.01), (1.0, 2.0, 3.0), (1.0, 2.0)])
-def test_point_valid_coordinates_json(coordinates):
-    """
-    Two or three number elements as coordinates shold be okay
-    """
-    p_json = json.dumps({"type": "Point", "coordinates": coordinates})
-    p = Point.validate(p_json)
     assert p.type == "Point"
     assert p.coordinates == coordinates
     assert hasattr(p, "__geo_interface__")
@@ -83,27 +69,6 @@ def test_multi_point_valid_coordinates(coordinates):
 
 @pytest.mark.parametrize(
     "coordinates",
-    [
-        [(1.0, 2.0)],
-        [(1.0, 2.0), (1.0, 2.0)],
-        [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0)],
-        [(1.0, 2.0), (1.0, 2.0)],
-    ],
-)
-def test_multi_point_valid_coordinates_json(coordinates):
-    """
-    Two or three number elements as coordinates shold be okay
-    """
-    p_json = json.dumps({"type": "MultiPoint", "coordinates": coordinates})
-    p = MultiPoint.validate(p_json)
-    assert p.type == "MultiPoint"
-    assert p.coordinates == coordinates
-    assert hasattr(p, "__geo_interface__")
-    assert_wkt_equivalence(p)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
     [[(1.0,)], [(1.0, 2.0, 3.0, 4.0)], ["Foo"], [(None, 2.0)], [(1.0, (2.0,))]],
 )
 def test_multi_point_invalid_coordinates(coordinates):
@@ -127,26 +92,6 @@ def test_line_string_valid_coordinates(coordinates):
     A list of two coordinates or more should be okay
     """
     linestring = LineString(coordinates=coordinates)
-    assert linestring.type == "LineString"
-    assert linestring.coordinates == coordinates
-    assert hasattr(linestring, "__geo_interface__")
-    assert_wkt_equivalence(linestring)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
-    [
-        [(1.0, 2.0), (3.0, 4.0)],
-        [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)],
-        [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
-    ],
-)
-def test_line_string_valid_coordinates_json(coordinates):
-    """
-    A list of two coordinates or more should be okay
-    """
-    linestring_json = json.dumps({"type": "LineString", "coordinates": coordinates})
-    linestring = LineString.validate(linestring_json)
     assert linestring.type == "LineString"
     assert linestring.coordinates == coordinates
     assert hasattr(linestring, "__geo_interface__")
@@ -182,28 +127,6 @@ def test_multi_line_string_valid_coordinates(coordinates):
 
 
 @pytest.mark.parametrize(
-    "coordinates",
-    [
-        [[(1.0, 2.0), (3.0, 4.0)]],
-        [[(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
-        [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]],
-    ],
-)
-def test_multi_line_string_valid_coordinates_json(coordinates):
-    """
-    A list of two coordinates or more should be okay
-    """
-    multilinestring_json = json.dumps(
-        {"type": "MultiLineString", "coordinates": coordinates}
-    )
-    multilinestring = MultiLineString.validate(multilinestring_json)
-    assert multilinestring.type == "MultiLineString"
-    assert multilinestring.coordinates == coordinates
-    assert hasattr(multilinestring, "__geo_interface__")
-    assert_wkt_equivalence(multilinestring)
-
-
-@pytest.mark.parametrize(
     "coordinates", [[None], ["Foo"], [[]], [[(1.0, 2.0)]], [["Foo", "Bar"]]]
 )
 def test_multi_line_string_invalid_coordinates(coordinates):
@@ -226,27 +149,6 @@ def test_polygon_valid_coordinates(coordinates):
     Should accept lists of linear rings
     """
     polygon = Polygon(coordinates=coordinates)
-    assert polygon.type == "Polygon"
-    assert polygon.coordinates == coordinates
-    assert hasattr(polygon, "__geo_interface__")
-    assert polygon.exterior == coordinates[0]
-    assert not list(polygon.interiors)
-    assert_wkt_equivalence(polygon)
-
-
-@pytest.mark.parametrize(
-    "coordinates",
-    [
-        [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]],
-        [[(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
-    ],
-)
-def test_polygon_valid_coordinates_json(coordinates):
-    """
-    Should accept lists of linear rings
-    """
-    polygon_json = json.dumps({"type": "Polygon", "coordinates": coordinates})
-    polygon = Polygon.validate(polygon_json)
     assert polygon.type == "Polygon"
     assert polygon.coordinates == coordinates
     assert hasattr(polygon, "__geo_interface__")


### PR DESCRIPTION
Per further discussion in: https://github.com/developmentseed/geojson-pydantic/discussions/66#discussioncomment-3294233

Can use `pydantic.Json[Polygon]` in a model to load from string.