### PR TITLE
allow Feature **id** to be either a String or a Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+- allow Feature's **id** to be either a String or a Number
+
 ## [0.5.0] - 2022-12-16
 
 ### Added

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -18,12 +18,13 @@ class Feature(GenericModel, Generic[Geom, Props]):
     type: str = Field(default="Feature", const=True)
     geometry: Optional[Geom] = None
     properties: Optional[Props] = None
-    id: Optional[str] = None
+    id: Optional[Union[int, str]] = None
     bbox: Optional[BBox] = None
 
     class Config:
         """Model configuration."""
 
+        smart_union = True
         use_enum_values = True
 
     @validator("geometry", pre=True, always=True)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -182,3 +182,14 @@ def test_feature_collection_geo_interface_with_null_geometry():
     assert "bbox" not in fc.__geo_interface__
     assert "bbox" not in fc.__geo_interface__["features"][0]
     assert "bbox" in fc.__geo_interface__["features"][1]
+
+
+def test_feature_id():
+    feature = Feature(**test_feature, id="A")
+    assert feature.id == "A"
+
+    feature = Feature(**test_feature, id=1)
+    assert feature.id == 1
+
+    feature = Feature(**test_feature, id="1")
+    assert feature.id == "1"


### PR DESCRIPTION
closes #90 

I'm a bit hesitant on this because pydantic smart-union is slower https://docs.pydantic.dev/usage/model_config/#smart-union

Maybe we can wait for pydantic v2 🤷 