### PR TITLE
Refactor WKT for reuse and speed.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         language_version: python
@@ -26,7 +26,7 @@ repos:
           - toml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
       - id: mypy
         language_version: python

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -17,6 +17,21 @@ from geojson_pydantic.types import (
 )
 
 
+def _position_wkt_coordinates(position: Position) -> str:
+    """Converts a Position to WKT Coordinates."""
+    return " ".join(str(number) for number in position)
+
+
+def _position_list_wkt_coordinates(positions: List[Position]) -> str:
+    """Converts a list of Positions to WKT Coordinates."""
+    return ", ".join(_position_wkt_coordinates(position) for position in positions)
+
+
+def _lines_wtk_coordinates(lines: List[List[Position]]) -> str:
+    """Converts lines to WKT Coordinates."""
+    return ", ".join(f"({_position_list_wkt_coordinates(line)})" for line in lines)
+
+
 class _GeometryBase(BaseModel, abc.ABC):
     """Base class for geometry models"""
 
@@ -50,7 +65,11 @@ class _GeometryBase(BaseModel, abc.ABC):
     @property
     def wkt(self) -> str:
         """Return the Well Known Text representation."""
-        return f"{self._wkt_type}{self._wkt_inset}({self._wkt_coordinates})"
+        return self._wkt_type + (
+            f"{self._wkt_inset}({self._wkt_coordinates})"
+            if self.coordinates
+            else " EMPTY"
+        )
 
 
 class Point(_GeometryBase):
@@ -61,7 +80,7 @@ class Point(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        return " ".join(str(coordinate) for coordinate in self.coordinates)
+        return _position_wkt_coordinates(self.coordinates)
 
     @property
     def _wkt_inset(self) -> str:
@@ -80,8 +99,7 @@ class MultiPoint(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        points = [Point(coordinates=p) for p in self.coordinates]
-        return ", ".join(point._wkt_coordinates for point in points)
+        return _position_list_wkt_coordinates(self.coordinates)
 
 
 class LineString(_GeometryBase):
@@ -96,8 +114,7 @@ class LineString(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        points = [Point(coordinates=p) for p in self.coordinates]
-        return ", ".join(point._wkt_coordinates for point in points)
+        return _position_list_wkt_coordinates(self.coordinates)
 
 
 class MultiLineString(_GeometryBase):
@@ -112,8 +129,7 @@ class MultiLineString(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        lines = [LineString(coordinates=line) for line in self.coordinates]
-        return ",".join(f"({line._wkt_coordinates})" for line in lines)
+        return _lines_wtk_coordinates(self.coordinates)
 
 
 class LinearRingGeom(LineString):
@@ -160,11 +176,7 @@ class Polygon(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        ic = "".join(
-            f", ({LinearRingGeom(coordinates=interior)._wkt_coordinates})"
-            for interior in self.interiors
-        )
-        return f"({LinearRingGeom(coordinates=self.exterior)._wkt_coordinates}){ic}"
+        return _lines_wtk_coordinates(self.coordinates)
 
     @classmethod
     def from_bounds(
@@ -190,8 +202,9 @@ class MultiPolygon(_GeometryBase):
 
     @property
     def _wkt_coordinates(self) -> str:
-        polygons = [Polygon(coordinates=poly) for poly in self.coordinates]
-        return ",".join(f"({poly._wkt_coordinates})" for poly in polygons)
+        return ",".join(
+            f"({_lines_wtk_coordinates(polygon)})" for polygon in self.coordinates
+        )
 
 
 Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -22,7 +22,7 @@ def assert_wkt_equivalence(geom: Union[Geometry, GeometryCollection]):
     """Assert WKT equivalence with Shapely."""
     # Remove any trailing `.0` to match Shapely format
     clean_wkt = re.sub(r"\.0(\D)", r"\1", geom.wkt)
-    assert shape(geom.dict()).wkt == clean_wkt
+    assert shape(geom).wkt == clean_wkt
 
 
 @pytest.mark.parametrize("coordinates", [(1.01, 2.01), (1.0, 2.0, 3.0), (1.0, 2.0)])
@@ -51,10 +51,11 @@ def test_point_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # No Z
         [(1.0, 2.0)],
         [(1.0, 2.0), (1.0, 2.0)],
+        # Has Z
         [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0)],
-        [(1.0, 2.0), (1.0, 2.0)],
     ],
 )
 def test_multi_point_valid_coordinates(coordinates):
@@ -83,9 +84,12 @@ def test_multi_point_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Two Points, no Z
         [(1.0, 2.0), (3.0, 4.0)],
-        [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)],
+        # Three Points, no Z
         [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
+        # Two Points, has Z
+        [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)],
     ],
 )
 def test_line_string_valid_coordinates(coordinates):
@@ -111,9 +115,16 @@ def test_line_string_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # One line, two points, no Z
         [[(1.0, 2.0), (3.0, 4.0)]],
+        # One line, two points, has Z
         [[(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
+        # One line, three points, no Z
         [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]],
+        # Two lines, two points each, no Z
+        [[(1.0, 2.0), (3.0, 4.0)], [(0.0, 0.0), (1.0, 1.0)]],
+        # Two lines, two points each, has Z
+        [[(1.0, 2.0, 0.0), (3.0, 4.0, 1.0)], [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
     ],
 )
 def test_multi_line_string_valid_coordinates(coordinates):
@@ -141,7 +152,9 @@ def test_multi_line_string_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Polygon, no Z
         [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]],
+        # Polygon, has Z
         [[(0.0, 0.0, 0.0), (1.0, 1.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0)]],
     ],
 )
@@ -158,14 +171,36 @@ def test_polygon_valid_coordinates(coordinates):
     assert_wkt_equivalence(polygon)
 
 
-def test_polygon_with_holes():
-    """Check interior and exterior rings."""
-    polygon = Polygon(
-        coordinates=[
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        # Polygon with holes, no Z
+        [
             [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)],
             [(2.0, 2.0), (2.0, 4.0), (4.0, 4.0), (4.0, 2.0), (2.0, 2.0)],
-        ]
-    )
+        ],
+        # Polygon with holes, has Z
+        [
+            [
+                (0.0, 0.0, 0.0),
+                (0.0, 10.0, 0.0),
+                (10.0, 10.0, 0.0),
+                (10.0, 0.0, 0.0),
+                (0.0, 0.0, 0.0),
+            ],
+            [
+                (2.0, 2.0, 1.0),
+                (2.0, 4.0, 1.0),
+                (4.0, 4.0, 1.0),
+                (4.0, 2.0, 1.0),
+                (2.0, 2.0, 1.0),
+            ],
+        ],
+    ],
+)
+def test_polygon_with_holes(coordinates):
+    """Check interior and exterior rings."""
+    polygon = Polygon(coordinates=coordinates)
 
     assert polygon.type == "Polygon"
     assert hasattr(polygon, "__geo_interface__")
@@ -196,10 +231,18 @@ def test_polygon_invalid_coordinates(coordinates):
         Polygon(coordinates=coordinates)
 
 
-def test_multi_polygon():
-    """Should accept sequence of polygons."""
-    multi_polygon = MultiPolygon(
-        coordinates=[
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        # Multipolygon, no Z
+        [
+            [
+                [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)],
+                [(2.1, 2.1), (2.2, 2.1), (2.2, 2.2), (2.1, 2.2), (2.1, 2.1)],
+            ]
+        ],
+        # Multipolygon, has Z
+        [
             [
                 [
                     (0.0, 0.0, 4.0),
@@ -216,8 +259,12 @@ def test_multi_polygon():
                     (2.1, 2.1, 4.0),
                 ],
             ]
-        ]
-    )
+        ],
+    ],
+)
+def test_multi_polygon(coordinates):
+    """Should accept sequence of polygons."""
+    multi_polygon = MultiPolygon(coordinates=coordinates)
 
     assert multi_polygon.type == "MultiPolygon"
     assert hasattr(multi_polygon, "__geo_interface__")


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Refactored WKT code to not instantiate new objects all the way down. The previous method had to construct and validate other geometry types to get the WKT. 
- Updated pre-commit versions because my local repo wouldn't let me commit without updating. Excluding `pydocstyle` which changed and threw a bunch of errors.  

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Created shared functions to reduce code duplication and make code easier to read.
- Used those functions recursively to avoid other geometries.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Kept existing tests, and updated as needed for additional cases. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Discussion #95 
- Issue #89 

This doesn't address one issue I noticed while testing: mixed dimensionality. Shapely doesn't allow for it. So a `MultiPoint(coordinates=[(0,0),(1,1,1)])` will become `MULTIPOINT Z (0 0 0, 1 1 1)` but we do not enforce that. Not sure where to go with that.

I would also like to use [hypothesis](https://hypothesis.readthedocs.io/en/latest/) to generate tests with the [pydantic hypothesis plugin](https://docs.pydantic.dev/hypothesis_plugin/) rather than having so many hard coded hard to read values. It would likely break for the above case, but it would be good to know more about where things are different. 