### PR TITLE
Allow empty coordinate arrays

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -207,6 +207,14 @@ class MultiPolygon(_GeometryBase):
             f"({_lines_wtk_coordinates(polygon)})" for polygon in self.coordinates
         )
 
+    @validator("coordinates")
+    def check_closure(cls, coordinates: List) -> List:
+        """Validate that Polygon is closed (first and last coordinate are the same)."""
+        if any([ring[-1] != ring[0] for polygon in coordinates for ring in polygon]):
+            raise ValueError("All linear rings have the same start and end coordinates")
+
+        return coordinates
+
 
 Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]
 

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -159,9 +159,9 @@ class Polygon(_GeometryBase):
         return coordinates
 
     @property
-    def exterior(self) -> LinearRing:
+    def exterior(self) -> Union[LinearRing, None]:
         """Return the exterior Linear Ring of the polygon."""
-        return self.coordinates[0]
+        return self.coordinates[0] if self.coordinates else None
 
     @property
     def interiors(self) -> Iterator[LinearRing]:
@@ -250,7 +250,11 @@ class GeometryCollection(BaseModel):
     @property
     def wkt(self) -> str:
         """Return the Well Known Text representation."""
-        return f"{self._wkt_type} ({self._wkt_coordinates})"
+        return (
+            self._wkt_type
+            + " "
+            + (f"({self._wkt_coordinates})" if self._wkt_coordinates else "EMPTY")
+        )
 
     @property
     def __geo_interface__(self) -> Dict[str, Any]:

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -15,14 +15,14 @@ Position = Union[Tuple[float, float], Tuple[float, float, float]]
 if TYPE_CHECKING:
     MultiPointCoords = List[Position]
     LineStringCoords = List[Position]
-    MultiLineStringCoords = List[List[Position]]
     LinearRing = List[Position]
+    MultiLineStringCoords = List[List[Position]]
     PolygonCoords = List[List[Position]]
     MultiPolygonCoords = List[List[List[Position]]]
 else:
-    MultiPointCoords = conlist(Position, min_items=1)
+    MultiPointCoords = conlist(Position)
     LineStringCoords = conlist(Position, min_items=2)
-    MultiLineStringCoords = conlist(LineStringCoords, min_items=1)
     LinearRing = conlist(Position, min_items=4)
-    PolygonCoords = conlist(LinearRing, min_items=1)
-    MultiPolygonCoords = conlist(PolygonCoords, min_items=1)
+    MultiLineStringCoords = conlist(LineStringCoords)
+    PolygonCoords = conlist(LinearRing)
+    MultiPolygonCoords = conlist(PolygonCoords)

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -11,18 +11,14 @@ BBox = Union[
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays
-
 if TYPE_CHECKING:
-    MultiPointCoords = List[Position]
     LineStringCoords = List[Position]
     LinearRing = List[Position]
-    MultiLineStringCoords = List[List[Position]]
-    PolygonCoords = List[List[Position]]
-    MultiPolygonCoords = List[List[List[Position]]]
 else:
-    MultiPointCoords = conlist(Position)
     LineStringCoords = conlist(Position, min_items=2)
     LinearRing = conlist(Position, min_items=4)
-    MultiLineStringCoords = conlist(LineStringCoords)
-    PolygonCoords = conlist(LinearRing)
-    MultiPolygonCoords = conlist(PolygonCoords)
+
+MultiPointCoords = List[Position]
+MultiLineStringCoords = List[LineStringCoords]
+PolygonCoords = List[LinearRing]
+MultiPolygonCoords = List[PolygonCoords]

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -28,7 +28,7 @@ def assert_wkt_equivalence(geom: Union[Geometry, GeometryCollection]):
 @pytest.mark.parametrize("coordinates", [(1.01, 2.01), (1.0, 2.0, 3.0), (1.0, 2.0)])
 def test_point_valid_coordinates(coordinates):
     """
-    Two or three number elements as coordinates shold be okay
+    Two or three number elements as coordinates should be okay
     """
     p = Point(type="Point", coordinates=coordinates)
     assert p.type == "Point"
@@ -38,7 +38,8 @@ def test_point_valid_coordinates(coordinates):
 
 
 @pytest.mark.parametrize(
-    "coordinates", [(1.0,), (1.0, 2.0, 3.0, 4.0), "Foo", (None, 2.0), (1.0, (2.0,))]
+    "coordinates",
+    [(1.0,), (1.0, 2.0, 3.0, 4.0), "Foo", (None, 2.0), (1.0, (2.0,)), (), [], None],
 )
 def test_point_invalid_coordinates(coordinates):
     """
@@ -51,6 +52,8 @@ def test_point_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Empty array
+        [],
         # No Z
         [(1.0, 2.0)],
         [(1.0, 2.0), (1.0, 2.0)],
@@ -60,7 +63,7 @@ def test_point_invalid_coordinates(coordinates):
 )
 def test_multi_point_valid_coordinates(coordinates):
     """
-    Two or three number elements as coordinates shold be okay
+    Two or three number elements as coordinates should be okay, as well as an empty array.
     """
     p = MultiPoint(type="MultiPoint", coordinates=coordinates)
     assert p.type == "MultiPoint"
@@ -71,7 +74,7 @@ def test_multi_point_valid_coordinates(coordinates):
 
 @pytest.mark.parametrize(
     "coordinates",
-    [[(1.0,)], [(1.0, 2.0, 3.0, 4.0)], ["Foo"], [(None, 2.0)], [(1.0, (2.0,))]],
+    [[(1.0,)], [(1.0, 2.0, 3.0, 4.0)], ["Foo"], [(None, 2.0)], [(1.0, (2.0,))], None],
 )
 def test_multi_point_invalid_coordinates(coordinates):
     """
@@ -115,6 +118,8 @@ def test_line_string_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Empty array
+        [],
         # One line, two points, no Z
         [[(1.0, 2.0), (3.0, 4.0)]],
         # One line, two points, has Z
@@ -139,7 +144,7 @@ def test_multi_line_string_valid_coordinates(coordinates):
 
 
 @pytest.mark.parametrize(
-    "coordinates", [[None], ["Foo"], [[]], [[(1.0, 2.0)]], [["Foo", "Bar"]]]
+    "coordinates", [None, [None], ["Foo"], [[]], [[(1.0, 2.0)]], [["Foo", "Bar"]]]
 )
 def test_multi_line_string_invalid_coordinates(coordinates):
     """
@@ -152,6 +157,8 @@ def test_multi_line_string_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Empty array
+        [],
         # Polygon, no Z
         [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]],
         # Polygon, has Z
@@ -166,7 +173,8 @@ def test_polygon_valid_coordinates(coordinates):
     assert polygon.type == "Polygon"
     assert polygon.coordinates == coordinates
     assert hasattr(polygon, "__geo_interface__")
-    assert polygon.exterior == coordinates[0]
+    if polygon.coordinates:
+        assert polygon.exterior == coordinates[0]
     assert not list(polygon.interiors)
     assert_wkt_equivalence(polygon)
 
@@ -212,10 +220,10 @@ def test_polygon_with_holes(coordinates):
     "coordinates",
     [
         "foo",
+        None,
         [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)], "foo", None],
         [[(1.0, 2.0), (3.0, 4.0), (1.0, 2.0)]],
         [[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)]],
-        [],
     ],
 )
 def test_polygon_invalid_coordinates(coordinates):
@@ -233,6 +241,8 @@ def test_polygon_invalid_coordinates(coordinates):
 @pytest.mark.parametrize(
     "coordinates",
     [
+        # Empty array
+        [],
         # Multipolygon, no Z
         [
             [
@@ -268,6 +278,26 @@ def test_multi_polygon(coordinates):
     assert multi_polygon.type == "MultiPolygon"
     assert hasattr(multi_polygon, "__geo_interface__")
     assert_wkt_equivalence(multi_polygon)
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        "foo",
+        None,
+        [
+            [
+                [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)],
+            ],
+            [
+                [(2.1, 2.1), (2.2, 2.1), (2.2, 2.2), (2.1, 4.2)],
+            ],
+        ],
+    ],
+)
+def test_multipolygon_invalid_coordinates(coordinates):
+    with pytest.raises(ValidationError):
+        MultiPolygon(type="MultiPolygon", coordinates=coordinates)
 
 
 def test_parse_geometry_obj_point():

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -175,6 +175,8 @@ def test_polygon_valid_coordinates(coordinates):
     assert hasattr(polygon, "__geo_interface__")
     if polygon.coordinates:
         assert polygon.exterior == coordinates[0]
+    else:
+        assert polygon.exterior is None
     assert not list(polygon.interiors)
     assert_wkt_equivalence(polygon)
 
@@ -467,4 +469,23 @@ def test_wkt_name():
     assert (
         PointType(type="Point", coordinates=(1.01, 2.01)).wkt
         == Point(type="Point", coordinates=(1.01, 2.01)).wkt
+    )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        MultiPoint,
+        MultiLineString,
+        Polygon,
+        MultiPolygon,
+    ],
+)
+def test_wkt_empty(shape):
+    assert shape(type=shape.__name__, coordinates=[]).wkt.endswith(" EMPTY")
+
+
+def test_wkt_empty_geometrycollection():
+    assert GeometryCollection(type="GeometryCollection", geometries=[]).wkt.endswith(
+        " EMPTY"
     )


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fix #89 and allow empty arrays. 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Removed `conlist` from the types which are not constrained. `LineString` and `LinearRing` still have min items. 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Tweaked existing tests, and added some new ones. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Issue: #89 
- Alternative to PR: #99 
