### PR TITLE
Add Geometry discriminator

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -3,8 +3,9 @@
 import abc
 from typing import Any, Dict, Iterator, List, Literal, Union
 
-from pydantic import BaseModel, ValidationError, validator
+from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
+from typing_extensions import Annotated
 
 from geojson_pydantic.types import (
     LinearRing,
@@ -208,7 +209,10 @@ class MultiPolygon(_GeometryBase):
         )
 
 
-Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]
+Geometry = Annotated[
+    Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon],
+    Field(discriminator="type"),
+]
 
 
 class GeometryCollection(BaseModel):


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add discriminator to `Geometry` to check less types, and simplify errors.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- `Annotated` it.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Existing tests still work. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Related: #93 

Unfortunately this PR does not do the second part, so I didn't way to say it fixes the issue entirely. 
```python
class Feature(GenericModel, Generic[Geom, Props]):
    ...
    geometry: Annotated[Union[Geom, None], Field(..., discriminator="type")]
```
Causes errors in the tests when the generic is overridden with a single `Geometry` type. It results in `TypeError: 'discriminator' can only be used with 'Union' type with more than one variant` 