### PR TITLE
Add has_z function to Geometries.

### DIFF
--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -438,3 +438,122 @@ def test_wkt_name():
         PointType(type="Point", coordinates=(1.01, 2.01)).wkt
         == Point(type="Point", coordinates=(1.01, 2.01)).wkt
     )
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ((0, 0), False),
+        ((0, 0, 0), True),
+    ],
+)
+def test_point_has_z(coordinates, expected):
+    assert Point(type="Point", coordinates=coordinates).has_z == expected
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ([(0, 0)], False),
+        ([(0, 0), (1, 1)], False),
+        ([(0, 0), (1, 1, 1)], True),
+        ([(0, 0, 0)], True),
+        ([(0, 0, 0), (1, 1)], True),
+    ],
+)
+def test_multipoint_has_z(coordinates, expected):
+    assert MultiPoint(type="MultiPoint", coordinates=coordinates).has_z == expected
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ([(0, 0), (1, 1)], False),
+        ([(0, 0), (1, 1, 1)], True),
+        ([(0, 0, 0), (1, 1, 1)], True),
+        ([(0, 0, 0), (1, 1)], True),
+    ],
+)
+def test_linestring_has_z(coordinates, expected):
+    assert LineString(type="LineString", coordinates=coordinates).has_z == expected
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ([[(0, 0), (1, 1)]], False),
+        ([[(0, 0), (1, 1)], [(0, 0), (1, 1)]], False),
+        ([[(0, 0), (1, 1)], [(0, 0, 0), (1, 1)]], True),
+        ([[(0, 0), (1, 1)], [(0, 0), (1, 1, 1)]], True),
+        ([[(0, 0), (1, 1, 1)]], True),
+        ([[(0, 0, 0), (1, 1, 1)]], True),
+        ([[(0, 0, 0), (1, 1)]], True),
+        ([[(0, 0, 0), (1, 1, 1)], [(0, 0, 0), (1, 1, 1)]], True),
+    ],
+)
+def test_multilinestring_has_z(coordinates, expected):
+    assert (
+        MultiLineString(type="MultiLineString", coordinates=coordinates).has_z
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ([[(0, 0), (1, 1), (2, 2), (0, 0)]], False),
+        ([[(0, 0), (1, 1), (2, 2, 2), (0, 0)]], True),
+        ([[(0, 0), (1, 1), (2, 2), (0, 0)], [(0, 0), (1, 1), (2, 2), (0, 0)]], False),
+        (
+            [[(0, 0), (1, 1), (2, 2), (0, 0)], [(0, 0), (1, 1), (2, 2, 2), (0, 0)]],
+            True,
+        ),
+        ([[(0, 0, 0), (1, 1, 1), (2, 2, 2), (0, 0, 0)]], True),
+        (
+            [
+                [(0, 0, 0), (1, 1, 1), (2, 2, 2), (0, 0, 0)],
+                [(0, 0), (1, 1), (2, 2), (0, 0)],
+            ],
+            True,
+        ),
+    ],
+)
+def test_polygon_has_z(coordinates, expected):
+    assert Polygon(type="Polygon", coordinates=coordinates).has_z == expected
+
+
+@pytest.mark.parametrize(
+    "coordinates,expected",
+    [
+        ([[[(0, 0), (1, 1), (2, 2), (0, 0)]]], False),
+        ([[[(0, 0), (1, 1), (2, 2, 2), (0, 0)]]], True),
+        (
+            [[[(0, 0), (1, 1), (2, 2), (0, 0)]], [[(0, 0), (1, 1), (2, 2), (0, 0)]]],
+            False,
+        ),
+        (
+            [
+                [[(0, 0), (1, 1), (2, 2), (0, 0)]],
+                [
+                    [(0, 0), (1, 1), (2, 2), (0, 0)],
+                    [(0, 0, 0), (1, 1, 1), (2, 2, 2), (0, 0, 0)],
+                ],
+            ],
+            True,
+        ),
+        (
+            [[[(0, 0), (1, 1), (2, 2), (0, 0)]], [[(0, 0), (1, 1), (2, 2, 2), (0, 0)]]],
+            True,
+        ),
+        ([[[(0, 0, 0), (1, 1, 1), (2, 2, 2), (0, 0, 0)]]], True),
+        (
+            [
+                [[(0, 0, 0), (1, 1, 1), (2, 2, 2), (0, 0, 0)]],
+                [[(0, 0), (1, 1), (2, 2), (0, 0)]],
+            ],
+            True,
+        ),
+    ],
+)
+def test_multipolygon_has_z(coordinates, expected):
+    assert MultiPolygon(type="MultiPolygon", coordinates=coordinates).has_z == expected


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add a `has_z` property to Geometries to simplify WKT and facilitate additional capabilities such as `force_2d` and `force_3d` in the future. 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Added helper functions to determine if any of the coordinates have a Z value
- Used those functions for the property each geometry type
- Removed individual `_wkt_inset` functions since we can reference `.has_z` 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- It was already being tested on some level some via WKT tests.
- Added tests dedicated to the function, including weird mixed dimensionality cases not covered in WKT

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Related #98
- Related #102
