### PR TITLE
[DO NOT MERGE] try generic position

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -26,7 +26,7 @@ class Feature(GenericModel, Generic[Geom, Props]):
 
         use_enum_values = True
 
-    @validator("geometry", pre=True, always=True)
+    @validator("geometry", pre=True)
     def set_geometry(cls, geometry: Any) -> Any:
         """set geometry from geo interface or input"""
         if hasattr(geometry, "__geo_interface__"):

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -13,10 +13,9 @@ from typing import (
     Union,
 )
 
-from pydantic import Field, ValidationError, conlist, validator
+from pydantic import ValidationError, conlist, validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.generics import GenericModel
-from typing_extensions import Annotated
 
 from geojson_pydantic.types import Position, Position2D, Position3D
 
@@ -264,31 +263,22 @@ class MultiPolygon(_GeometryBase, Generic[_Position]):
         return coordinates
 
 
-Geometry = Annotated[
-    Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon],
-    Field(discriminator="type"),
+Geometry = Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon]
+Geometry2D = Union[
+    Point[Position2D],
+    MultiPoint[Position2D],
+    LineString[Position2D],
+    MultiLineString[Position2D],
+    Polygon[Position2D],
+    MultiPolygon[Position2D],
 ]
-Geometry2D = Annotated[
-    Union[
-        Point[Position2D],
-        MultiPoint[Position2D],
-        LineString[Position2D],
-        MultiLineString[Position2D],
-        Polygon[Position2D],
-        MultiPolygon[Position2D],
-    ],
-    Field(discriminator="type"),
-]
-Geometry3D = Annotated[
-    Union[
-        Point[Position3D],
-        MultiPoint[Position3D],
-        LineString[Position3D],
-        MultiLineString[Position3D],
-        Polygon[Position3D],
-        MultiPolygon[Position3D],
-    ],
-    Field(discriminator="type"),
+Geometry3D = Union[
+    Point[Position3D],
+    MultiPoint[Position3D],
+    LineString[Position3D],
+    MultiLineString[Position3D],
+    Polygon[Position3D],
+    MultiPolygon[Position3D],
 ]
 
 _Geometry = TypeVar("_Geometry", bound=Geometry)
@@ -358,16 +348,22 @@ def parse_geometry_obj(obj: Any) -> Geometry:
         )
     if obj["type"] == "Point":
         return Point.parse_obj(obj)
+
     elif obj["type"] == "MultiPoint":
         return MultiPoint.parse_obj(obj)
+
     elif obj["type"] == "LineString":
         return LineString.parse_obj(obj)
+
     elif obj["type"] == "MultiLineString":
         return MultiLineString.parse_obj(obj)
+
     elif obj["type"] == "Polygon":
         return Polygon.parse_obj(obj)
+
     elif obj["type"] == "MultiPolygon":
         return MultiPolygon.parse_obj(obj)
+
     raise ValidationError(
         errors=[ErrorWrapper(ValueError("Unknown type"), loc="type")],
         model=_GeometryBase,

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -18,7 +18,7 @@ from pydantic.error_wrappers import ErrorWrapper
 from pydantic.generics import GenericModel
 from typing_extensions import Annotated
 
-from geojson_pydantic.types import Position
+from geojson_pydantic.types import Position, Position2D, Position3D
 
 _Position = TypeVar("_Position", bound=Position)
 
@@ -266,6 +266,28 @@ class MultiPolygon(_GeometryBase, Generic[_Position]):
 
 Geometry = Annotated[
     Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon],
+    Field(discriminator="type"),
+]
+Geometry2D = Annotated[
+    Union[
+        Point[Position2D],
+        MultiPoint[Position2D],
+        LineString[Position2D],
+        MultiLineString[Position2D],
+        Polygon[Position2D],
+        MultiPolygon[Position2D],
+    ],
+    Field(discriminator="type"),
+]
+Geometry3D = Annotated[
+    Union[
+        Point[Position3D],
+        MultiPoint[Position3D],
+        LineString[Position3D],
+        MultiLineString[Position3D],
+        Polygon[Position3D],
+        MultiPolygon[Position3D],
+    ],
     Field(discriminator="type"),
 ]
 

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,24 +1,11 @@
 """Types for geojson_pydantic models"""
 
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import Tuple, Union
 
-from pydantic import conlist
+BBox2D = Tuple[float, float, float, float]
+BBox3D = Tuple[float, float, float, float, float, float]
+BBox = Union[BBox2D, BBox3D]
 
-BBox = Union[
-    Tuple[float, float, float, float],  # 2D bbox
-    Tuple[float, float, float, float, float, float],  # 3D bbox
-]
-Position = Union[Tuple[float, float], Tuple[float, float, float]]
-
-# Coordinate arrays
-if TYPE_CHECKING:
-    LineStringCoords = List[Position]
-    LinearRing = List[Position]
-else:
-    LineStringCoords = conlist(Position, min_items=2)
-    LinearRing = conlist(Position, min_items=4)
-
-MultiPointCoords = List[Position]
-MultiLineStringCoords = List[LineStringCoords]
-PolygonCoords = List[LinearRing]
-MultiPolygonCoords = List[PolygonCoords]
+Position2D = Tuple[float, float]
+Position3D = Tuple[float, float, float]
+Position = Union[Position2D, Position3D]


### PR DESCRIPTION
This is a try at solving (at least partially) https://github.com/developmentseed/geojson-pydantic/issues/98

```python
from geojson_pydantic.types import Position2D, Position3D
from geojson_pydantic import Point

p2 = Point[Position2D]
>> p2(type="Point", coordinates=(0,0,0))
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 p2(type="Point", coordinates=(0,0,0))

ValidationError: 1 validation error for Point[Tuple[float, float]]
coordinates
  wrong tuple length 3, expected 2 (type=value_error.tuple.length; actual_length=3; expected_length=2)

p2(type="Point", coordinates=(0,0))
>> Point[Tuple[float, float]](type='Point', coordinates=(0.0, 0.0))


p = Polygon[Position3D]
p(type="Polygon", coordinates=[[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]])
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Input In [21], in <cell line: 1>()
----> 1 p(type="Polygon", coordinates=[[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0)]])

ValidationError: 4 validation errors for Polygon[Tuple[float, float, float]]
coordinates -> 0 -> 0
  wrong tuple length 2, expected 3 (type=value_error.tuple.length; actual_length=2; expected_length=3)
coordinates -> 0 -> 1
  wrong tuple length 2, expected 3 (type=value_error.tuple.length; actual_length=2; expected_length=3)
coordinates -> 0 -> 2
  wrong tuple length 2, expected 3 (type=value_error.tuple.length; actual_length=2; expected_length=3)
coordinates -> 0 -> 3
  wrong tuple length 2, expected 3 (type=value_error.tuple.length; actual_length=2; expected_length=3)
```


@eseglem what do you think about this? 

cc @geospatial-jeff 