### PR TITLE
Refactor geo_interface to use a standardized mixin.

### DIFF
--- a/geojson_pydantic/geo_interface.py
+++ b/geojson_pydantic/geo_interface.py
@@ -1,0 +1,23 @@
+"""Mixin for __geo_interface__ on GeoJSON objects."""
+
+from typing import Any, Dict, Protocol
+
+
+class DictProtocol(Protocol):
+    """Protocol for use as the type of self in the mixin."""
+
+    def dict(self, *, exclude_unset: bool, **args: Any) -> Dict[str, Any]:
+        """Define a dict function so the mixin knows it exists."""
+        ...
+
+
+class GeoInterfaceMixin:
+    """Mixin for __geo_interface__ on GeoJSON objects."""
+
+    @property
+    def __geo_interface__(self: DictProtocol) -> Dict[str, Any]:
+        """GeoJSON-like protocol for geo-spatial (GIS) vector data.
+
+        ref: https://gist.github.com/sgillies/2217756#__geo_interface
+        """
+        return self.dict(exclude_unset=True)

--- a/geojson_pydantic/geo_interface.py
+++ b/geojson_pydantic/geo_interface.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, Protocol
 
 
-class DictProtocol(Protocol):
+class _DictProtocol(Protocol):
     """Protocol for use as the type of self in the mixin."""
 
     def dict(self, *, exclude_unset: bool, **args: Any) -> Dict[str, Any]:
@@ -15,7 +15,7 @@ class GeoInterfaceMixin:
     """Mixin for __geo_interface__ on GeoJSON objects."""
 
     @property
-    def __geo_interface__(self: DictProtocol) -> Dict[str, Any]:
+    def __geo_interface__(self: _DictProtocol) -> Dict[str, Any]:
         """GeoJSON-like protocol for geo-spatial (GIS) vector data.
 
         ref: https://gist.github.com/sgillies/2217756#__geo_interface


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Refactored the code to use a single function for all `__geo_interface__` methods. Because the models represent geojson already returning themselves as a dict is all that is necessary. This implementation aligns with what other libraries are doing as well as the discussion in #96. The original gist pre-dates the current geojson spec and has some slight inconsistencies, but the intent is to match geojson.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Added a standard mixin for `__geo_interface__` to use on the models. 
- Use `self.dict()` for the response.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- No tests were changed and they all still pass. 
- The primary test for this is probably a bit implicit inside the WKT tests. Since shapely reads the `__geo_interface__` and then produces the same WKT as our WKT functions we know it is producing usable data in `__geo_interface__`

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #96 

I prefer consolidating code where I can, so I did it as a mixin. If it is preferable, we could just have the function on each of the models directly rather than a mixin. Since mixins do add to complexity of understanding.  I was using this as a way to learn the right way to do a mixin like this in pydantic and keep everything happy. So it has at least served that purpose. 