### PR TITLE
Remove unused LinearRingGeom class.

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -132,18 +132,6 @@ class MultiLineString(_GeometryBase):
         return _lines_wtk_coordinates(self.coordinates)
 
 
-class LinearRingGeom(LineString):
-    """LinearRing model."""
-
-    @validator("coordinates")
-    def check_closure(cls, coordinates: List) -> List:
-        """Validate that LinearRing is closed (first and last coordinate are the same)."""
-        if coordinates[-1] != coordinates[0]:
-            raise ValueError("LinearRing must have the same start and end coordinates")
-
-        return coordinates
-
-
 class Polygon(_GeometryBase):
     """Polygon Model"""
 


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Remove the `LinearRingGeom` class. It doesn't correspond with an actual GeoJSON type and it is not used in any other part of the code. It also had no tests or anything related to it. 
 
I think this probably originated from the desire to have the validation on the coordinates and not inside Polygon, but it was not actually being used. I have been experimenting with a class for `LinearRingCoords` that may end up similar with the validation is inside the type and not on Polygon. But if I can get it working that will be a different PR. 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Remove the LinearRingGeom class.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- This code wasn't actually used anywhere, and didn't have any related tests. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- I had originally included this in an earlier PR that got split up (#85), but I didn't remember it was still there until recently.

