### PR TITLE
Address mixed dimensionality in wkt

### DIFF
--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -275,12 +275,20 @@ class GeometryCollection(BaseModel):
     @property
     def wkt(self) -> str:
         """Return the Well Known Text representation."""
-        coordinates = (
+        # Each geometry will check its own coordinates for Z and include "Z" in the wkt
+        # if necessary. Rather than looking at the coordinates for each of the geometries
+        # again, we can just get the wkt from each of them and check if there is a Z
+        # anywhere in the text.
+
+        # Get the wkt from each of the geometries in the collection
+        geometries = (
             f'({", ".join(geom.wkt for geom in self.geometries)})'
             if self.geometries
             else "EMPTY"
         )
-        return f"{self.type.upper()} {coordinates}"
+        # If any of them contain `Z` add Z to the output wkt
+        z = " Z " if "Z" in geometries else " "
+        return f"{self.type.upper()}{z}{geometries}"
 
     @property
     def __geo_interface__(self) -> Dict[str, Any]:

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -59,6 +59,8 @@ def test_point_invalid_coordinates(coordinates):
         [(1.0, 2.0), (1.0, 2.0)],
         # Has Z
         [(1.0, 2.0, 3.0), (1.0, 2.0, 3.0)],
+        # Mixed
+        [(1.0, 2.0), (1.0, 2.0, 3.0)],
     ],
 )
 def test_multi_point_valid_coordinates(coordinates):
@@ -93,6 +95,7 @@ def test_multi_point_invalid_coordinates(coordinates):
         [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
         # Two Points, has Z
         [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)],
+        # Shapely doesn't like mixed here
     ],
 )
 def test_line_string_valid_coordinates(coordinates):
@@ -130,6 +133,8 @@ def test_line_string_invalid_coordinates(coordinates):
         [[(1.0, 2.0), (3.0, 4.0)], [(0.0, 0.0), (1.0, 1.0)]],
         # Two lines, two points each, has Z
         [[(1.0, 2.0, 0.0), (3.0, 4.0, 1.0)], [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
+        # Mixed
+        [[(1.0, 2.0), (3.0, 4.0)], [(0.0, 0.0, 0.0), (1.0, 1.0, 1.0)]],
     ],
 )
 def test_multi_line_string_valid_coordinates(coordinates):
@@ -206,6 +211,17 @@ def test_polygon_valid_coordinates(coordinates):
                 (2.0, 2.0, 1.0),
             ],
         ],
+        # Mixed
+        [
+            [(0.0, 0.0), (0.0, 10.0), (10.0, 10.0), (10.0, 0.0), (0.0, 0.0)],
+            [
+                (2.0, 2.0, 2.0),
+                (2.0, 4.0, 0.0),
+                (4.0, 4.0, 0.0),
+                (4.0, 2.0, 0.0),
+                (2.0, 2.0, 2.0),
+            ],
+        ],
     ],
 )
 def test_polygon_with_holes(coordinates):
@@ -268,6 +284,19 @@ def test_polygon_invalid_coordinates(coordinates):
                     (2.2, 2.2, 4.0),
                     (2.1, 2.2, 4.0),
                     (2.1, 2.1, 4.0),
+                ],
+            ]
+        ],
+        # Mixed
+        [
+            [
+                [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)],
+                [
+                    (2.1, 2.1, 2.1),
+                    (2.2, 2.1, 2.0),
+                    (2.2, 2.2, 2.2),
+                    (2.1, 2.2, 2.3),
+                    (2.1, 2.1, 2.1),
                 ],
             ]
         ],
@@ -450,6 +479,18 @@ def test_getitem_geometry_collection(polygon):
     assert_wkt_equivalence(gc)
     item = gc[0]
     assert item == gc[0]
+
+
+def test_wkt_mixed_geometry_collection():
+    point = Point(type="Point", coordinates=(0.0, 0.0, 0.0))
+    line_string = LineString(type="LineString", coordinates=[(0.0, 0.0), (1.0, 1.0)])
+    gc = GeometryCollection(type="GeometryCollection", geometries=[point, line_string])
+    assert_wkt_equivalence(gc)
+
+
+def test_wkt_empty_geometry_collection():
+    gc = GeometryCollection(type="GeometryCollection", geometries=[])
+    assert_wkt_equivalence(gc)
 
 
 def test_polygon_from_bounds():


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Addressing mixed dimensionality edge case on WKT functions.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Add capability to `force_z` in wkt functions.
- Use `has_z` to determine when to force the inclusion of z.
- Adjust signatures to work together. 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- All the current tests still work. 

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #102 

---

It was a bit weirder than I wanted to only run `has_z` once at the top level. I iterated way too many times on figuring out the best way to set the wkt coordinate functions at the class level. I think I am finally OK with how its set up. 

- [x] Add tests specific to mixed dimensions. 
- [x] Verify how `Z` is used on GeometryCollection in spec and adjust if needed. (Maybe wait for follow on PR?) 
- ~~Move helper functions to `wkt.py`?~~