### PR TITLE
Add BBox to Geometries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     ```
 
 - Add has_z function to Geometries (author @eseglem, https://github.com/developmentseed/geojson-pydantic/pull/103)
+- Add optional bbox to geometries.
 
 ### Changed
 

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -1,7 +1,7 @@
 """pydantic models for GeoJSON Geometry objects."""
 
 import abc
-from typing import Any, Iterator, List, Literal, Union
+from typing import Any, Iterator, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
@@ -9,6 +9,7 @@ from typing_extensions import Annotated
 
 from geojson_pydantic.geo_interface import GeoInterfaceMixin
 from geojson_pydantic.types import (
+    BBox,
     LinearRing,
     LineStringCoords,
     MultiLineStringCoords,
@@ -55,6 +56,7 @@ class _GeometryBase(BaseModel, abc.ABC, GeoInterfaceMixin):
 
     type: str
     coordinates: Any
+    bbox: Optional[BBox] = None
 
     @property
     @abc.abstractmethod
@@ -238,6 +240,7 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
 
     type: Literal["GeometryCollection"]
     geometries: List[Geometry]
+    bbox: Optional[BBox] = None
 
     def __iter__(self) -> Iterator[Geometry]:  # type: ignore [override]
         """iterate over geometries"""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -168,7 +168,7 @@ def test_geo_interface_protocol():
         __geo_interface__ = {"type": "Point", "coordinates": (0.0, 0.0)}
 
     feat = Feature(type="Feature", geometry=Pointy(), properties={})
-    assert feat.geometry.dict() == Pointy.__geo_interface__
+    assert feat.geometry.dict(exclude_unset=True) == Pointy.__geo_interface__
 
 
 def test_feature_with_null_geometry():


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add BBox to Geometries.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Add optional bbox to `_GeometryBase` and `GeometryCollection`

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Only one minor tweak to a test. Don't think anything new is needed for the optional field.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- n/a

I was looking over some CQL2 stuff and got confused when I saw an optional BBox on their Geometries, but technically that is correct. 

> A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections.