### PR TITLE
Additional bbox validation.

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -7,7 +7,7 @@ from pydantic.generics import GenericModel
 
 from geojson_pydantic.geo_interface import GeoInterfaceMixin
 from geojson_pydantic.geometries import Geometry, GeometryCollection
-from geojson_pydantic.types import BBox
+from geojson_pydantic.types import BBox, validate_bbox
 
 Props = TypeVar("Props", bound=Union[Dict[str, Any], BaseModel])
 Geom = TypeVar("Geom", bound=Union[Geometry, GeometryCollection])
@@ -21,6 +21,8 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     properties: Union[Props, None] = Field(...)
     id: Optional[Union[StrictInt, StrictStr]] = None
     bbox: Optional[BBox] = None
+
+    _validate_bbox = validator("bbox", allow_reuse=True)(validate_bbox)
 
     @validator("geometry", pre=True, always=True)
     def set_geometry(cls, geometry: Any) -> Any:
@@ -49,3 +51,5 @@ class FeatureCollection(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     def __getitem__(self, index: int) -> Feature:
         """get feature at a given index"""
         return self.features[index]
+
+    _validate_bbox = validator("bbox", allow_reuse=True)(validate_bbox)

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -22,28 +22,6 @@ class Feature(GenericModel, Generic[Geom, Props], GeoInterfaceMixin):
     id: Optional[Union[StrictInt, StrictStr]] = None
     bbox: Optional[BBox] = None
 
-    class Config:
-        """Model configuration."""
-
-        use_enum_values = True
-
-    @validator("bbox", pre=True)
-    def check_bbox(cls, bbox: BBox) -> BBox:
-        """Check that bbox is valid."""
-        if len(bbox) == 6:
-            if bbox[0] > bbox[3] or bbox[1] > bbox[4] or bbox[2] > bbox[5]:  # type: ignore
-                raise ValueError(
-                    "BBox must be in the form [west, south, bottom, east, north, top]"
-                )
-        elif len(bbox) == 4:
-            if bbox[0] > bbox[2] or bbox[1] > bbox[3]:
-                raise ValueError("BBox must be in the form [west, south, east, north]")
-        else:
-            raise ValueError(
-                "BBox must be in the form [west, south, east, north] or [west, south, bottom, east, north, top]"
-            )
-        return bbox
-
     @validator("geometry", pre=True, always=True)
     def set_geometry(cls, geometry: Any) -> Any:
         """set geometry from geo interface or input"""

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -19,6 +19,7 @@ from geojson_pydantic.types import (
     MultiPolygonCoords,
     PolygonCoords,
     Position,
+    validate_bbox,
 )
 
 
@@ -106,6 +107,8 @@ class _GeometryBase(BaseModel, abc.ABC, GeoInterfaceMixin):
             wkt += " EMPTY"
 
         return wkt
+
+    _validate_bbox = validator("bbox", allow_reuse=True)(validate_bbox)
 
 
 class Point(_GeometryBase):
@@ -286,6 +289,8 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
         # If any of them contain `Z` add Z to the output wkt
         z = " Z " if "Z" in geometries else " "
         return f"{self.type.upper()}{z}{geometries}"
+
+    _validate_bbox = validator("bbox", allow_reuse=True)(validate_bbox)
 
     @validator("geometries")
     def check_geometries(cls, geometries: List) -> List:

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,63 +1,45 @@
 """Types for geojson_pydantic models"""
 
-from typing import TYPE_CHECKING, Any, Callable, Generator, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
-from pydantic import ConstrainedList, conlist
+from pydantic import conlist
 
+T = TypeVar("T")
 
-class _BBoxBase(ConstrainedList):
-    """Base Class with additional Validation for order."""
-
-    # This is needed because pydantic checks it rather than `item_type`
-    __args__ = (float,)
-
-    item_type = float
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[..., Any], None, None]:
-        """Yield the validators."""
-        yield from super().__get_validators__()
-        yield cls.validate_bbox
-
-    @classmethod
-    def validate_bbox(cls, bbox: List[float]) -> List[float]:
-        """Validate BBox values are ordered correctly."""
-        if not bbox:
-            return bbox
-
-        offset = len(bbox) // 2
-        errors: List[str] = []
-        # Check X
-        if bbox[0] > bbox[offset]:
-            errors.append(f"Min X ({bbox[0]}) must be <= Max X ({bbox[offset]}).")
-        # Check Y
-        if bbox[1] > bbox[1 + offset]:
-            errors.append(f"Min Y ({bbox[1]}) must be <= Max Y ({bbox[1 + offset]}).")
-        # If 3D, check Z values.
-        if offset > 2 and bbox[2] > bbox[2 + offset]:
-            errors.append(f"Min Z ({bbox[2]}) must be <= Max Z ({bbox[2 + offset]}).")
-
-        if errors:
-            raise ValueError("Invalid BBox. Error(s): " + " ".join(errors))
-
-        return bbox
+BBox = Union[
+    Tuple[float, float, float, float], Tuple[float, float, float, float, float, float]
+]
 
 
-class BBox2D(_BBoxBase):
-    """2D Bounding Box"""
+def validate_bbox(bbox: Optional[BBox]) -> Optional[BBox]:
+    """Validate BBox values are ordered correctly."""
+    # If bbox is None, there is nothing to validate.
+    if bbox is None:
+        return None
 
-    min_items = 4
-    max_items = 4
+    # A list to store any errors found so we can raise them all at once.
+    errors: List[str] = []
+
+    # Determine where the second position starts. 2 for 2D, 3 for 3D.
+    offset = len(bbox) // 2
+
+    # Check X
+    if bbox[0] > bbox[offset]:
+        errors.append(f"Min X ({bbox[0]}) must be <= Max X ({bbox[offset]}).")
+    # Check Y
+    if bbox[1] > bbox[1 + offset]:
+        errors.append(f"Min Y ({bbox[1]}) must be <= Max Y ({bbox[1 + offset]}).")
+    # If 3D, check Z values.
+    if offset > 2 and bbox[2] > bbox[2 + offset]:
+        errors.append(f"Min Z ({bbox[2]}) must be <= Max Z ({bbox[2 + offset]}).")
+
+    # Raise any errors found.
+    if errors:
+        raise ValueError("Invalid BBox. Error(s): " + " ".join(errors))
+
+    return bbox
 
 
-class BBox3D(_BBoxBase):
-    """3D Bounding Box"""
-
-    min_items = 6
-    max_items = 6
-
-
-BBox = Union[BBox3D, BBox2D]
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -7,7 +7,8 @@ from pydantic import conlist
 T = TypeVar("T")
 
 BBox = Union[
-    Tuple[float, float, float, float], Tuple[float, float, float, float, float, float]
+    Tuple[float, float, float, float],  # 2D bbox
+    Tuple[float, float, float, float, float, float],  # 3D bbox
 ]
 
 

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,13 +1,63 @@
 """Types for geojson_pydantic models"""
 
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Generator, List, Tuple, Union
 
-from pydantic import conlist
+from pydantic import ConstrainedList, conlist
 
-BBox = Union[
-    Tuple[float, float, float, float],  # 2D bbox
-    Tuple[float, float, float, float, float, float],  # 3D bbox
-]
+
+class _BBoxBase(ConstrainedList):
+    """Base Class with additional Validation for order."""
+
+    # This is needed because pydantic checks it rather than `item_type`
+    __args__ = (float,)
+
+    item_type = float
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[..., Any], None, None]:
+        """Yield the validators."""
+        yield from super().__get_validators__()
+        yield cls.validate_bbox
+
+    @classmethod
+    def validate_bbox(cls, bbox: List[float]) -> List[float]:
+        """Validate BBox values are ordered correctly."""
+        if not bbox:
+            return bbox
+
+        offset = len(bbox) // 2
+        errors: List[str] = []
+        # Check X
+        if bbox[0] > bbox[offset]:
+            errors.append(f"Min X ({bbox[0]}) must be <= Max X ({bbox[offset]}).")
+        # Check Y
+        if bbox[1] > bbox[1 + offset]:
+            errors.append(f"Min Y ({bbox[1]}) must be <= Max Y ({bbox[1 + offset]}).")
+        # If 3D, check Z values.
+        if offset > 2 and bbox[2] > bbox[2 + offset]:
+            errors.append(f"Min Z ({bbox[2]}) must be <= Max Z ({bbox[2 + offset]}).")
+
+        if errors:
+            raise ValueError("Invalid BBox. Error(s): " + " ".join(errors))
+
+        return bbox
+
+
+class BBox2D(_BBoxBase):
+    """2D Bounding Box"""
+
+    min_items = 4
+    max_items = 4
+
+
+class BBox3D(_BBoxBase):
+    """3D Bounding Box"""
+
+    min_items = 6
+    max_items = 6
+
+
+BBox = Union[BBox3D, BBox2D]
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -232,8 +232,26 @@ def test_feature_validation():
 
     with pytest.raises(ValidationError):
         # bad bbox2d
-        Feature(type="Feature", properties=None, bbox=[100, 100, 0, 0])
+        Feature(type="Feature", properties=None, bbox=(100, 100, 0, 0), geometry=None)
 
     with pytest.raises(ValidationError):
         # bad bbox3d
-        Feature(type="Feature", properties=None, bbox=[100, 100, 100, 0, 0, 0])
+        Feature(
+            type="Feature",
+            properties=None,
+            bbox=(100, 100, 100, 0, 0, 0),
+            geometry=None,
+        )
+
+
+def test_bbox_validation():
+    # Some attempts at generic validation did not validate the types within
+    # bbox before passing them to the function and resulted in TypeErrors.
+    # This test exists to ensure that doesn't happen in the future.
+    with pytest.raises(ValidationError):
+        Feature(
+            type="Feature",
+            properties=None,
+            bbox=(0, "a", 0, 1, 1, 1),
+            geometry=None,
+        )


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Add consistent bbox validation across the board.
- Add more specific validation errors to bbox. 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Create a generic bbox validation function, and re-use it everywhere.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Existing tests, plus one additional.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #118 reminded me of what I had done, so I finished cleaning it up.

I tried a lot of different ways to accomplish this with mixins and such, but none of it worked out for Pydantic 1.x. Mostly had issues with differences between `GenericModel` and `BaseModel`. Looks like there are probably better ways to do some of this for Pydantic 2.x, but haven't dug into it yet. Just wanted to push this so I wouldn't forget again. 
