### PR TITLE
limit pydantic requirement to 1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
         # No reason to run if only tests have changed. They intentionally break typing.
         exclude: tests/.*
         additional_dependencies:
-        - pydantic
+        - pydantic~=1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommanded to pin geojson-pydantic to minor version: `geojson-pydantic>=0.6,<0.7`
 
+## [0.6.3] - 2023-07-02
+
+* limit pydantic requirement to `~=1.0``
 
 ## [0.6.2] - 2023-05-16
 
@@ -286,7 +289,8 @@ Although the type file was added in `0.2.0` it wasn't included in the distribute
 ### Added
 - Initial Release
 
-[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.2...HEAD
+[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.3...HEAD
+[0.6.3]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.2...0.6.3
 [0.6.2]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.1...0.6.2
 [0.6.1]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.0a0...0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ plugins = ["pydantic.mypy"]
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-warn_untyped_fields = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["pydantic"]
+dependencies = ["pydantic~=1.0"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "shapely"]


### PR DESCRIPTION
```
tests/test_package.py:1: in <module>
    import geojson_pydantic
geojson_pydantic/__init__.py:3: in <module>
    from .features import Feature, FeatureCollection  # noqa
geojson_pydantic/features.py:6: in <module>
    from pydantic.generics import GenericModel
E   ImportError: cannot import name 'GenericModel' from 'pydantic.generics' (/Users/vincentsarago/Dev/venv/py39/lib/python3.9/site-packages/pydantic/generics.py)
```

we will update the pydantic version in `1.0`