### PR TITLE
Tweak Geometry to include GeometryCollection. Fixes: #93

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -5,11 +5,11 @@ from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVa
 from pydantic import BaseModel, Field, StrictInt, StrictStr, field_validator
 
 from geojson_pydantic.geo_interface import GeoInterfaceMixin
-from geojson_pydantic.geometries import Geometry, GeometryCollection
+from geojson_pydantic.geometries import Geometry
 from geojson_pydantic.types import BBox, validate_bbox
 
 Props = TypeVar("Props", bound=Union[Dict[str, Any], BaseModel])
-Geom = TypeVar("Geom", bound=Union[Geometry, GeometryCollection])
+Geom = TypeVar("Geom", bound=Geometry)
 
 
 class Feature(BaseModel, Generic[Geom, Props], GeoInterfaceMixin):

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -246,20 +246,14 @@ class MultiPolygon(_GeometryBase):
         return coordinates
 
 
-Geometry = Annotated[
-    Union[Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon],
-    Field(discriminator="type"),
-]
-
-
 class GeometryCollection(BaseModel, GeoInterfaceMixin):
     """GeometryCollection Model"""
 
     type: Literal["GeometryCollection"]
-    geometries: List[Union[Geometry, GeometryCollection]]
+    geometries: List[Geometry]
     bbox: Optional[BBox] = None
 
-    def __iter__(self) -> Iterator[Union[Geometry, GeometryCollection]]:  # type: ignore [override]
+    def __iter__(self) -> Iterator[Geometry]:  # type: ignore [override]
         """iterate over geometries"""
         return iter(self.geometries)
 
@@ -267,7 +261,7 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
         """return geometries length"""
         return len(self.geometries)
 
-    def __getitem__(self, index: int) -> Union[Geometry, GeometryCollection]:
+    def __getitem__(self, index: int) -> Geometry:
         """get geometry at a given index"""
         return self.geometries[index]
 
@@ -312,6 +306,20 @@ class GeometryCollection(BaseModel, GeoInterfaceMixin):
         return geometries
 
 
+Geometry = Annotated[
+    Union[
+        Point,
+        MultiPoint,
+        LineString,
+        MultiLineString,
+        Polygon,
+        MultiPolygon,
+        GeometryCollection,
+    ],
+    Field(discriminator="type"),
+]
+
+
 def parse_geometry_obj(obj: Any) -> Geometry:
     """
     `obj` is an object that is supposed to represent a GeoJSON geometry. This method returns the
@@ -337,5 +345,8 @@ def parse_geometry_obj(obj: Any) -> Geometry:
 
     elif obj["type"] == "MultiPolygon":
         return MultiPolygon.parse_obj(obj)
+
+    elif obj["type"] == "GeometryCollection":
+        return GeometryCollection.model_validate(obj)
 
     raise ValueError(f"Unknown type: {obj['type']}")

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -1,8 +1,9 @@
 """Types for geojson_pydantic models"""
 
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
+from typing import List, Optional, Tuple, TypeVar, Union
 
-from pydantic import conlist
+from pydantic import Field
+from typing_extensions import Annotated
 
 T = TypeVar("T")
 
@@ -44,13 +45,8 @@ def validate_bbox(bbox: Optional[BBox]) -> Optional[BBox]:
 Position = Union[Tuple[float, float], Tuple[float, float, float]]
 
 # Coordinate arrays
-if TYPE_CHECKING:
-    LineStringCoords = List[Position]
-    LinearRing = List[Position]
-else:
-    LineStringCoords = conlist(Position, min_length=2)
-    LinearRing = conlist(Position, min_length=4)
-
+LineStringCoords = Annotated[List[Position], Field(min_length=2)]
+LinearRing = Annotated[List[Position], Field(min_length=4)]
 MultiPointCoords = List[Position]
 MultiLineStringCoords = List[LineStringCoords]
 PolygonCoords = List[LinearRing]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -263,3 +263,30 @@ def test_bbox_validation():
             bbox=(0, "a", 0, 1, 1, 1),
             geometry=None,
         )
+
+
+def test_feature_validation_error_count():
+    # Tests that validation does not include irrelevant errors to make them
+    # easier to read. The input below used to raise 18 errors.
+    # See #93 for more details.
+    with pytest.raises(ValidationError):
+        try:
+            Feature(
+                type="Feature",
+                geometry=Polygon(
+                    type="Polygon",
+                    coordinates=[
+                        [
+                            (-55.9947406591177, -9.26104045526505),
+                            (-55.9976752102375, -9.266589696568962),
+                            (-56.00200328975916, -9.264041751931352),
+                            (-55.99899921566248, -9.257935213034594),
+                            (-55.99477406591177, -9.26103945526505),
+                        ]
+                    ],
+                ),
+                properties={},
+            )
+        except ValidationError as e:
+            assert e.error_count() == 1
+            raise

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -427,6 +427,24 @@ def test_parse_geometry_obj_multi_polygon():
     )
 
 
+def test_parse_geometry_obj_geometry_collection():
+    assert parse_geometry_obj(
+        {
+            "type": "GeometryCollection",
+            "geometries": [
+                {"type": "Point", "coordinates": [102.0, 0.5]},
+                {"type": "MultiPoint", "coordinates": [[100.0, 0.0], [101.0, 1.0]]},
+            ],
+        }
+    ) == GeometryCollection(
+        type="GeometryCollection",
+        geometries=[
+            Point(type="Point", coordinates=(102.0, 0.5)),
+            MultiPoint(type="MultiPoint", coordinates=[(100.0, 0.0), (101.0, 1.0)]),
+        ],
+    )
+
+
 def test_parse_geometry_obj_invalid_type():
     with pytest.raises(ValueError):
         parse_geometry_obj({"type": "This type", "obviously": "doesn't exist"})


### PR DESCRIPTION
Pointed at `pydantic2.0` branch for now since it is branched from there. It is meant to be pointed to `develop` after that branch is merged. Can switch it from Draft to Ready whenever. 

## What I am changing
<!-- What were the high-level goals of the change? -->
- Finish fixing #93 
- Added `GeometryCollection` case to `parse_geometry_obj`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- By adding `GeometryCollection` into the `Geometry` type we no longer have the issue with a second discriminator. 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- All the existing tests continue to pass.
- Added a test to check the the example from #93 results in a single `ValidationError`. 
- Added a test for parsing a `GeometryCollection` in `parse_geometry_obj`

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Fixes #93 the rest of the way. 
- This was probably mostly enabled by #110 / #111 but the 2.0 update may have helped as well. 
