### PR TITLE
refactor: :art: Modify FeatureCollection generic

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -32,14 +32,17 @@ class Feature(BaseModel, Generic[Geom, Props], GeoInterfaceMixin):
         return geometry
 
 
-class FeatureCollection(BaseModel, Generic[Geom, Props], GeoInterfaceMixin):
+Feat = TypeVar("Feat", bound=Feature)
+
+
+class FeatureCollection(BaseModel, Generic[Feat], GeoInterfaceMixin):
     """FeatureCollection Model"""
 
     type: Literal["FeatureCollection"]
-    features: List[Feature[Geom, Props]]
+    features: List[Feat]
     bbox: Optional[BBox] = None
 
-    def __iter__(self) -> Iterator[Feature]:  # type: ignore [override]
+    def __iter__(self) -> Iterator[Feat]:  # type: ignore [override]
         """iterate over features"""
         return iter(self.features)
 
@@ -47,7 +50,7 @@ class FeatureCollection(BaseModel, Generic[Geom, Props], GeoInterfaceMixin):
         """return features length"""
         return len(self.features)
 
-    def __getitem__(self, index: int) -> Feature:
+    def __getitem__(self, index: int) -> Feat:
         """get feature at a given index"""
         return self.features[index]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -73,18 +73,14 @@ test_feature_geometry_collection: Dict[str, Any] = {
 
 def test_feature_collection_iteration():
     """test if feature collection is iterable"""
-    gc = FeatureCollection(
-        type="FeatureCollection", features=[test_feature, test_feature]
-    )
+    gc = FeatureCollection(type="FeatureCollection", features=[test_feature, test_feature])
     assert hasattr(gc, "__geo_interface__")
     iter(gc)
 
 
 def test_geometry_collection_iteration():
     """test if feature collection is iterable"""
-    gc = FeatureCollection(
-        type="FeatureCollection", features=[test_feature_geometry_collection]
-    )
+    gc = FeatureCollection(type="FeatureCollection", features=[test_feature_geometry_collection])
     assert hasattr(gc, "__geo_interface__")
     iter(gc)
 
@@ -100,9 +96,7 @@ def test_generic_properties_is_dict():
 def test_generic_properties_is_dict_collection():
     feature = Feature(**test_feature_geometry_collection)
     assert hasattr(feature, "__geo_interface__")
-    assert (
-        feature.properties["id"] == test_feature_geometry_collection["properties"]["id"]
-    )
+    assert feature.properties["id"] == test_feature_geometry_collection["properties"]["id"]
     assert type(feature.properties) == dict
     assert not hasattr(feature.properties, "id")
 
@@ -132,9 +126,7 @@ def test_generic_geometry():
 
 
 def test_generic_geometry_collection():
-    feature = Feature[GeometryCollection, GenericProperties](
-        **test_feature_geometry_collection
-    )
+    feature = Feature[GeometryCollection, GenericProperties](**test_feature_geometry_collection)
     assert feature.properties.id == test_feature_geometry_collection["properties"]["id"]
     assert type(feature.geometry) == GeometryCollection
     assert feature.geometry.wkt.startswith("GEOMETRYCOLLECTION (POLYGON ")
@@ -143,9 +135,7 @@ def test_generic_geometry_collection():
 
     feature = Feature[GeometryCollection, Dict](**test_feature_geometry_collection)
     assert type(feature.geometry) == GeometryCollection
-    assert (
-        feature.properties["id"] == test_feature_geometry_collection["properties"]["id"]
-    )
+    assert feature.properties["id"] == test_feature_geometry_collection["properties"]["id"]
     assert type(feature.properties) == dict
     assert not hasattr(feature.properties, "id")
 
@@ -155,13 +145,11 @@ def test_generic_geometry_collection():
 
 def test_generic_properties_should_raise_for_string():
     with pytest.raises(ValidationError):
-        Feature(
-            **({"type": "Feature", "geometry": polygon, "properties": "should raise"})
-        )
+        Feature(**({"type": "Feature", "geometry": polygon, "properties": "should raise"}))
 
 
 def test_feature_collection_generic():
-    fc = FeatureCollection[Polygon, GenericProperties](
+    fc = FeatureCollection[Feature[Polygon, GenericProperties]](
         type="FeatureCollection", features=[test_feature, test_feature]
     )
     assert len(fc) == 2
@@ -231,12 +219,8 @@ def test_feature_validation():
         # missing geometry
         Feature(type="Feature", properties=None)
 
-    assert Feature(
-        type="Feature", properties=None, bbox=(0, 0, 100, 100), geometry=None
-    )
-    assert Feature(
-        type="Feature", properties=None, bbox=(0, 0, 0, 100, 100, 100), geometry=None
-    )
+    assert Feature(type="Feature", properties=None, bbox=(0, 0, 100, 100), geometry=None)
+    assert Feature(type="Feature", properties=None, bbox=(0, 0, 0, 100, 100, 100), geometry=None)
 
     with pytest.raises(ValidationError):
         # bad bbox2d


### PR DESCRIPTION
Modify the FeatureCollection generic to depends only on a generic Feature instead of a Geoemtry and Properties

The FeatureCollection generic instantiation is changed from FeatureCollection[MyGeometry, MyProperties] to FeatureCollection[MyFeature]

From issue [#134](https://github.com/developmentseed/geojson-pydantic/issues/134)