### PR TITLE
Tweak WKT generation and tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note: Minor version `0.X.0` update might break the API, It's recommanded to pin 
 ### Fixed
 
 * reduce validation error message verbosity when discriminating Geometry types
+* MultiPoint WKT now includes parentheses around each Point
 
 ### Added
 

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -67,7 +67,7 @@ def _lines_has_z(lines: List[LineStringCoords]) -> bool:
 def _polygons_wkt_coordinates(
     coordinates: List[PolygonCoords], force_z: bool = False
 ) -> str:
-    return ",".join(
+    return ", ".join(
         f"({_lines_wtk_coordinates(polygon, force_z)})" for polygon in coordinates
     )
 
@@ -134,7 +134,11 @@ class MultiPoint(_GeometryBase):
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
         """return WKT coordinates."""
-        return _position_list_wkt_coordinates(coordinates, force_z)
+        # return _position_list_wkt_coordinates(coordinates, force_z)
+        return ", ".join(
+            f"({_position_wkt_coordinates(position, force_z)})"
+            for position in coordinates
+        )
 
     @property
     def has_z(self) -> bool:
@@ -319,7 +323,7 @@ Geometry = Annotated[
     Field(discriminator="type"),
 ]
 
-GeometryCollection.update_forward_refs()
+GeometryCollection.model_rebuild()
 
 
 def parse_geometry_obj(obj: Any) -> Geometry:

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -134,7 +134,6 @@ class MultiPoint(_GeometryBase):
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
         """return WKT coordinates."""
-        # return _position_list_wkt_coordinates(coordinates, force_z)
         return ", ".join(
             f"({_position_wkt_coordinates(position, force_z)})"
             for position in coordinates


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Attempt to fix issues with WKT and its tests.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Adjusted `MultiPoint` to include parentheses around each set of Point coordinates.
- Adjusted tests because we can no longer rely on a consistent output from Shapely / Geos.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Attempted to address all the cases in a new test.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Fixes #139 Though some of the fix is just avoiding the issues in Shapely / Geos not changing anything for us. 

The `NaN` behavior in Geos is weird, as it is not valid WKT, but I understand what they are doing rather than assuming `0.0` as the Z value. It doesn't look entirely resolved on the Shapely side either, so I don't think there is much to do for now. Unless we just stop using the `force_z` stuff, and let stuff like `"MULTIPOINT Z ((0.0 0.0), (1.0 1.0 1.0))"` be output. It is parseable by `shapely.from_wkt` at least. So maybe that is not so bad? I think the reason for how it was was because their output added the 0, so we did too. 