### PR TITLE
Adjust model serializer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin geojson-pydantic to minor version: `geojson-pydantic>=0.6,<0.7`
 
+## [1.0.1] - 2023-10-04
+
+### Fixed
+
+* Model serialization when using include/exclude (ref: https://github.com/developmentseed/geojson-pydantic/pull/148)
+
 ## [1.0.0] - 2023-07-24
 
 ### Fixed
@@ -342,7 +348,8 @@ Although the type file was added in `0.2.0` it wasn't included in the distribute
 ### Added
 - Initial Release
 
-[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/1.0.0...HEAD
+[unreleased]: https://github.com/developmentseed/geojson-pydantic/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/developmentseed/geojson-pydantic/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.3...1.0.0
 [0.6.3]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.2...0.6.3
 [0.6.2]: https://github.com/developmentseed/geojson-pydantic/compare/0.6.1...0.6.2

--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -61,6 +61,7 @@ class _GeoJsonBase(BaseModel):
         # This seems like the best way to have the least amount of unexpected consequences.
         # We want to avoid forcing values in `exclude_none` or `exclude_unset` which could
         # cause issues or unexpected behavior for downstream users.
+        # ref: https://github.com/pydantic/pydantic/issues/6575
         data: Dict[str, Any] = serializer(self)
 
         # Only remove fields when in JSON mode.

--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -52,8 +52,8 @@ class _GeoJsonBase(BaseModel):
 
         return bbox
 
-    @model_serializer(when_used="json", mode="wrap")
-    def clean_model(self, serializer: Any, _info: SerializationInfo) -> Dict[str, Any]:
+    @model_serializer(when_used="always", mode="wrap")
+    def clean_model(self, serializer: Any, info: SerializationInfo) -> Dict[str, Any]:
         """Custom Model serializer to match the GeoJSON specification.
 
         Used to remove fields which are optional but cannot be null values.
@@ -62,7 +62,11 @@ class _GeoJsonBase(BaseModel):
         # We want to avoid forcing values in `exclude_none` or `exclude_unset` which could
         # cause issues or unexpected behavior for downstream users.
         data: Dict[str, Any] = serializer(self)
-        for field in self.__geojson_exclude_if_none__:
-            if field in data and data[field] is None:
-                del data[field]
+
+        # Only remove fields when in JSON mode.
+        if info.mode_is_json():
+            for field in self.__geojson_exclude_if_none__:
+                if field in data and data[field] is None:
+                    del data[field]
+
         return data

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -321,6 +321,14 @@ def test_feature_serializer():
     assert "bbox" in f.model_dump()
     assert "id" in f.model_dump()
 
+    # Exclude
+    assert "bbox" not in f.model_dump(exclude={"bbox"})
+    assert "bbox" not in list(json.loads(f.model_dump_json(exclude={"bbox"})).keys())
+
+    # Include
+    assert ["bbox"] == list(f.model_dump(include={"bbox"}).keys())
+    assert ["bbox"] == list(json.loads(f.model_dump_json(include={"bbox"})).keys())
+
     feat_ser = json.loads(f.model_dump_json())
     assert "bbox" in feat_ser
     assert "id" in feat_ser
@@ -336,6 +344,8 @@ def test_feature_serializer():
             "properties": {},
         }
     )
+    # BBOX Should'nt be present if `None`
+    # https://github.com/developmentseed/geojson-pydantic/issues/125
     assert "bbox" in f.model_dump()
 
     feat_ser = json.loads(f.model_dump_json())
@@ -380,6 +390,14 @@ def test_feature_collection_serializer():
         }
     )
     assert "bbox" in fc.model_dump()
+
+    # Exclude
+    assert "bbox" not in fc.model_dump(exclude={"bbox"})
+    assert "bbox" not in list(json.loads(fc.model_dump_json(exclude={"bbox"})).keys())
+
+    # Include
+    assert ["bbox"] == list(fc.model_dump(include={"bbox"}).keys())
+    assert ["bbox"] == list(json.loads(fc.model_dump_json(include={"bbox"})).keys())
 
     featcoll_ser = json.loads(fc.model_dump_json())
     assert "bbox" in featcoll_ser


### PR DESCRIPTION
Fixes #147.

```
>>> f.model_dump(include={"geometry"})
{'geometry': {'bbox': None, 'type': 'Polygon', 'coordinates': [[(-123.07498674, 44.04971882), (-123.07554223, 44.06248623), (-123.0625126, 44.06278031), (-123.06195992, 44.05001283), (-123.07498674, 44.04971882)]]}}
>>> f.model_dump(exclude={"geometry"})
{'bbox': None, 'type': 'Feature', 'properties': {'a': 1, 'b': 2, 'c': 3}, 'id': None}
>>> f.model_dump_json()
'{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-123.07498674,44.04971882],[-123.07554223,44.06248623],[-123.0625126,44.06278031],[-123.06195992,44.05001283],[-123.07498674,44.04971882]]]},"properties":{"a":1,"b":2,"c":3}}'
>>> f.model_dump_json(include={"geometry"})
'{"geometry":{"type":"Polygon","coordinates":[[[-123.07498674,44.04971882],[-123.07554223,44.06248623],[-123.0625126,44.06278031],[-123.06195992,44.05001283],[-123.07498674,44.04971882]]]}}'
>>> f.model_dump_json(exclude={"geometry"})
'{"type":"Feature","properties":{"a":1,"b":2,"c":3}}'
```


Not sure why the serializer isn't applied properly when not in "json" mode the other way, but this appears to fix it.

Probably worth adding some tests, but I have to head out and can't right now. 