### PR TITLE
Workaround for #150 FastAPI shows no attributes for models.

### DIFF
--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -53,7 +53,7 @@ class _GeoJsonBase(BaseModel):
         return bbox
 
     @model_serializer(when_used="always", mode="wrap")
-    def clean_model(self, serializer: Any, info: SerializationInfo) -> Any:
+    def clean_model(self, serializer: Any, info: SerializationInfo):  # type: ignore [no-untyped-def]
         """Custom Model serializer to match the GeoJSON specification.
 
         Used to remove fields which are optional but cannot be null values.

--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -52,6 +52,8 @@ class _GeoJsonBase(BaseModel):
 
         return bbox
 
+    # This return is untyped due to a workaround until this issue is resolved:
+    # https://github.com/tiangolo/fastapi/discussions/10661
     @model_serializer(when_used="always", mode="wrap")
     def clean_model(self, serializer: Any, info: SerializationInfo):  # type: ignore [no-untyped-def]
         """Custom Model serializer to match the GeoJSON specification.

--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -53,7 +53,7 @@ class _GeoJsonBase(BaseModel):
         return bbox
 
     @model_serializer(when_used="always", mode="wrap")
-    def clean_model(self, serializer: Any, info: SerializationInfo) -> Dict[str, Any]:
+    def clean_model(self, serializer: Any, info: SerializationInfo):
         """Custom Model serializer to match the GeoJSON specification.
 
         Used to remove fields which are optional but cannot be null values.

--- a/geojson_pydantic/base.py
+++ b/geojson_pydantic/base.py
@@ -53,7 +53,7 @@ class _GeoJsonBase(BaseModel):
         return bbox
 
     @model_serializer(when_used="always", mode="wrap")
-    def clean_model(self, serializer: Any, info: SerializationInfo):
+    def clean_model(self, serializer: Any, info: SerializationInfo) -> Any:
         """Custom Model serializer to match the GeoJSON specification.
 
         Used to remove fields which are optional but cannot be null values.

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -339,6 +339,13 @@ def test_parse_geometry_obj_point():
     )
 
 
+def test_schema():
+    """Test to check that the schema is the same for validation and serialization"""
+    assert Point.model_json_schema(mode="validation") == Point.model_json_schema(
+        mode="serialization"
+    )
+
+
 def test_parse_geometry_obj_multi_point():
     assert parse_geometry_obj(
         {"type": "MultiPoint", "coordinates": [[100.0, 0.0], [101.0, 1.0]]}

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -339,11 +339,23 @@ def test_parse_geometry_obj_point():
     )
 
 
-def test_schema():
+@pytest.mark.parametrize(
+    "geojson_pydantic_model",
+    (
+        GeometryCollection,
+        LineString,
+        MultiLineString,
+        MultiPoint,
+        MultiPolygon,
+        Point,
+        Polygon,
+    ),
+)
+def test_schema_consistency(geojson_pydantic_model):
     """Test to check that the schema is the same for validation and serialization"""
-    assert Point.model_json_schema(mode="validation") == Point.model_json_schema(
-        mode="serialization"
-    )
+    assert geojson_pydantic_model.model_json_schema(
+        mode="validation"
+    ) == geojson_pydantic_model.model_json_schema(mode="serialization")
 
 
 def test_parse_geometry_obj_multi_point():


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- This is a temporary workaround until https://github.com/tiangolo/fastapi/discussions/10661 is answered in a better way. I am just making this available here in case someone else would like to use it. I can finalise it better(changelog and such) if this is something that wants to be merged into main.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Changing the typehinting according to workaround mention [here](https://github.com/tiangolo/fastapi/discussions/10661#discussioncomment-7631104) to get the model to show up in fast api swagger docs.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- See https://github.com/developmentseed/geojson-pydantic/issues/150 for a simple case.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- https://github.com/developmentseed/geojson-pydantic/issues/150
