### PR TITLE
Add default values for type Literals

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -14,7 +14,7 @@ Geom = TypeVar("Geom", bound=Geometry)
 class Feature(_GeoJsonBase, Generic[Geom, Props]):
     """Feature Model"""
 
-    type: Literal["Feature"]
+    type: Literal["Feature"] = "Feature"
     geometry: Union[Geom, None] = Field(...)
     properties: Union[Props, None] = Field(...)
     id: Optional[Union[StrictInt, StrictStr]] = None
@@ -36,7 +36,7 @@ Feat = TypeVar("Feat", bound=Feature)
 class FeatureCollection(_GeoJsonBase, Generic[Feat]):
     """FeatureCollection Model"""
 
-    type: Literal["FeatureCollection"]
+    type: Literal["FeatureCollection"] = "FeatureCollection"
     features: List[Feat]
 
     def __iter__(self) -> Iterator[Feat]:  # type: ignore [override]

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -108,7 +108,7 @@ class _GeometryBase(_GeoJsonBase, abc.ABC):
 class Point(_GeometryBase):
     """Point Model"""
 
-    type: Literal["Point"]
+    type: Literal["Point"] = "Point"
     coordinates: Position
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -124,7 +124,7 @@ class Point(_GeometryBase):
 class MultiPoint(_GeometryBase):
     """MultiPoint Model"""
 
-    type: Literal["MultiPoint"]
+    type: Literal["MultiPoint"] = "MultiPoint"
     coordinates: MultiPointCoords
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -143,7 +143,7 @@ class MultiPoint(_GeometryBase):
 class LineString(_GeometryBase):
     """LineString Model"""
 
-    type: Literal["LineString"]
+    type: Literal["LineString"] = "LineString"
     coordinates: LineStringCoords
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -159,7 +159,7 @@ class LineString(_GeometryBase):
 class MultiLineString(_GeometryBase):
     """MultiLineString Model"""
 
-    type: Literal["MultiLineString"]
+    type: Literal["MultiLineString"] = "MultiLineString"
     coordinates: MultiLineStringCoords
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -175,7 +175,7 @@ class MultiLineString(_GeometryBase):
 class Polygon(_GeometryBase):
     """Polygon Model"""
 
-    type: Literal["Polygon"]
+    type: Literal["Polygon"] = "Polygon"
     coordinates: PolygonCoords
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -223,7 +223,7 @@ class Polygon(_GeometryBase):
 class MultiPolygon(_GeometryBase):
     """MultiPolygon Model"""
 
-    type: Literal["MultiPolygon"]
+    type: Literal["MultiPolygon"] = "MultiPolygon"
     coordinates: MultiPolygonCoords
 
     def __wkt_coordinates__(self, coordinates: Any, force_z: bool) -> str:
@@ -247,7 +247,7 @@ class MultiPolygon(_GeometryBase):
 class GeometryCollection(_GeoJsonBase):
     """GeometryCollection Model"""
 
-    type: Literal["GeometryCollection"]
+    type: Literal["GeometryCollection"] = "GeometryCollection"
     geometries: List[Geometry]
 
     def __iter__(self) -> Iterator[Geometry]:  # type: ignore [override]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -233,10 +233,6 @@ def test_feature_validation():
         Feature(type="feature", properties=None, geometry=None)
 
     with pytest.raises(ValidationError):
-        # missing type
-        Feature(properties=None, geometry=None)
-
-    with pytest.raises(ValidationError):
         # missing properties
         Feature(type="Feature", geometry=None)
 
@@ -425,3 +421,11 @@ def test_feature_collection_serializer():
     assert "bbox" not in featcoll_ser
     assert "bbox" not in featcoll_ser["features"][0]
     assert "bbox" not in featcoll_ser["features"][0]["geometry"]
+
+
+def test_feature_defauls():
+    feature = Feature(properties=None, geometry=None)
+    assert feature.type == "Feature"
+
+    feature_collection = FeatureCollection(features=[])
+    assert feature_collection.type == "FeatureCollection"

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -891,3 +891,26 @@ def test_geometry_collection_serializer():
     assert "bbox" in geom_ser
     assert "bbox" not in geom_ser["geometries"][0]
     assert "bbox" not in geom_ser["geometries"][1]
+
+
+def test_defaults():
+    geometry_collection = GeometryCollection(geometries=[])
+    assert geometry_collection.type == "GeometryCollection"
+
+    line_string = LineString(coordinates=[(0.0, 0.0), (1.0, 1.0)])
+    assert line_string.type == "LineString"
+
+    multiline_string = MultiLineString(coordinates=[])
+    assert multiline_string.type == "MultiLineString"
+
+    multi_point = MultiPoint(coordinates=[])
+    assert multi_point.type == "MultiPoint"
+
+    multi_polygon = MultiPolygon(coordinates=[])
+    assert multi_polygon.type == "MultiPolygon"
+
+    point = Point(coordinates=[0, 0])
+    assert point.type == "Point"
+
+    polygon = Polygon(coordinates=[])
+    assert polygon.type == "Polygon"


### PR DESCRIPTION
Hello `geojson-pydantic` team!

Please consider this small improvement. 
I find it useful :slightly_smiling_face: 


## What I am changing
Default constructors no longer require `type` argument. 

### Before:

```python
Point(type="Point", coordinates=[0, 0])
```

### After:
```python
Point(coordinates=[0, 0])
```

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
Added defaults for all `Literal`s.

### Example:
```diff
- type: Literal["Point"]
+ type: Literal["Point"] = "Point"
```

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
By running [the tests](https://github.com/developmentseed/geojson-pydantic/pull/160/files#diff-1787233a4c8792eec865bf3d857d1907387dce9f27474922da0cf1400f072e5fR896-R916).

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
The [test for missing type](https://github.com/developmentseed/geojson-pydantic/pull/160/files#diff-d8c7322bad71404522a489cb47c789fd4e6ec02b09f93563b51c1d599d4d9707L235-L238) is no longer valid, so I removed it.

```Python
   with pytest.raises(ValidationError):
       # missing type
       Feature(properties=None, geometry=None)
```