### PR TITLE
Switch to Pydantic v1 namespace and allow Pydantic v1 or v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
         # No reason to run if only tests have changed. They intentionally break typing.
         exclude: tests/.*
         additional_dependencies:
-        - pydantic~=1.0
+        - pydantic>1.10.18,<3

--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, validator
+from pydantic.v1.generics import GenericModel
 
 from geojson_pydantic.geo_interface import GeoInterfaceMixin
 from geojson_pydantic.geometries import Geometry, GeometryCollection

--- a/geojson_pydantic/geometries.py
+++ b/geojson_pydantic/geometries.py
@@ -5,8 +5,8 @@ import abc
 import warnings
 from typing import Any, Iterator, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, ValidationError, validator
-from pydantic.error_wrappers import ErrorWrapper
+from pydantic.v1 import BaseModel, Field, ValidationError, validator
+from pydantic.v1.error_wrappers import ErrorWrapper
 from typing_extensions import Annotated
 
 from geojson_pydantic.geo_interface import GeoInterfaceMixin

--- a/geojson_pydantic/types.py
+++ b/geojson_pydantic/types.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
-from pydantic import conlist
+from pydantic.v1 import conlist
 
 T = TypeVar("T")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["pydantic~=1.0"]
+dependencies = ["pydantic>1.10.18,<3"]
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov", "shapely"]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 from uuid import uuid4
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 from geojson_pydantic.features import Feature, FeatureCollection
 from geojson_pydantic.geometries import (

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -2,7 +2,7 @@ import re
 from typing import Union
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from shapely.geometry import shape
 
 from geojson_pydantic.geometries import (


### PR DESCRIPTION
## What I am changing
This change incorporates the use of the Pydantic v1 namespace which was introduced in Pydantic 1.10.17 and all 2.x versions. This allows the use of Pydantic v1 while also supporting either Pydantic >=1.10.17,<3. The goal being to allow users of this package a planned upgrade path to Pydantic 2.x instead of an abrupt switch.

See https://github.com/developmentseed/geojson-pydantic/issues/166 for more on this issue

## How I did it
- Changed the Pydantic dependency to >1.10.18 (latest) and <3 (all 2.x versions)
- Changing all Pydantic import statements to use the `v1` namespace (e.g. `from pydantic.v1 import ...`)

## How you can test it
- Verified all existing unit tests pass
- Verified existing functionality works as expected on private services

## Reference
See the Pydantic migration guide which was updated to reference the new v1 namespace support back in August: https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features