### PR TITLE
propose .make method to create Features without needing to specify all parameters

### DIFF
--- a/geojson_pydantic/features.py
+++ b/geojson_pydantic/features.py
@@ -1,11 +1,14 @@
 """pydantic models for GeoJSON Feature objects."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, Iterator, List, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field, StrictInt, StrictStr, field_validator
 
 from geojson_pydantic.base import _GeoJsonBase
 from geojson_pydantic.geometries import Geometry
+from geojson_pydantic.types import BBox
 
 Props = TypeVar("Props", bound=Union[Dict[str, Any], BaseModel])
 Geom = TypeVar("Geom", bound=Geometry)
@@ -28,6 +31,26 @@ class Feature(_GeoJsonBase, Generic[Geom, Props]):
             return geometry.__geo_interface__
 
         return geometry
+
+    @staticmethod
+    def make(
+        *,
+        type: Literal["Feature"] = "Feature",
+        geometry: Optional[Geom] = None,
+        properties: Optional[Props] = None,
+        id: Optional[Union[StrictInt, StrictStr]] = None,
+        bbox: Optional[BBox] = None,
+    ) -> Feature:
+        """Allow to create a Feature without needint to specify all arguments.
+        In particular it is not necessary to specify the redundant `type="Feature"`.
+        """
+        return Feature(
+            type=type,
+            geometry=geometry,
+            properties=properties,
+            id=id,
+            bbox=bbox,
+        )
 
 
 Feat = TypeVar("Feat", bound=Feature)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -59,6 +59,9 @@ test_feature: Dict[str, Any] = {
     "bbox": [13.38272, 52.46385, 13.42786, 52.48445],
 }
 
+test_feature_no_type: Dict[str, Any] = test_feature.copy()
+test_feature_no_type.pop("type")
+
 test_feature_geom_null: Dict[str, Any] = {
     "type": "Feature",
     "geometry": None,
@@ -229,6 +232,17 @@ def test_bad_feature_id(id):
         Feature(**test_feature, id=id)
 
 
+def test_feature_make():
+    # Using make it is possible to create a valid Feature without specifying
+    # redundant information, e.g. `type="Feature"`:
+    feature = Feature.make()
+    assert feature.type == "Feature"
+    feature = Feature.make(properties={"foo": "bar"})
+    assert feature.type == "Feature"
+    assert feature.geometry is None
+    assert feature.properties == {"foo": "bar"}
+
+
 def test_feature_validation():
     """Test default."""
     assert Feature(type="Feature", properties=None, geometry=None)
@@ -281,6 +295,13 @@ def test_feature_validation():
             bbox=(100, 0, 0, 0, 100, 100),
             geometry=None,
         )
+
+
+def test_deserialization():
+    Feature.model_validate(test_feature)
+    # type missing
+    with pytest.raises(ValidationError):
+        Feature.model_validate(test_feature_no_type)
 
 
 def test_bbox_validation():


### PR DESCRIPTION
I would like to propos to add a `make` function to the pydantic models that will take the arguments but with 'sane defaults'.

Using this, some redundant information can be omitted:

```
feature_now = Feature(type="Feature", geometry=LineString(type="LineString", coordinates=[(0,1),(1,1)]))
feature_proposed = Feature.make(geometry=LineString.make(coordinates=[(0,1),(1,1)]))
```

If you think this is a fair idea, I can add `make`s for the other types as well.